### PR TITLE
feat(contracts): Upgrade capability with 48h timelock (#33)

### DIFF
--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -1,5 +1,5 @@
 use shared::errors::Error;
-use shared::types::{Amount, EscrowInfo, Milestone, PauseState};
+use shared::types::{Amount, EscrowInfo, Milestone, PauseState, PendingUpgrade};
 use soroban_sdk::{Address, Env};
 
 /// Storage keys for escrow data structures
@@ -148,6 +148,7 @@ pub fn get_total_milestone_amount(env: &Env, project_id: u64) -> Result<Amount, 
 }
 
 const PAUSE_STATE_KEY: &str = "pause_state";
+const PENDING_UPGRADE_KEY: &str = "pending_upgrade";
 
 /// Store the pause state
 pub fn set_pause_state(env: &Env, state: &PauseState) {
@@ -169,4 +170,24 @@ pub fn get_pause_state(env: &Env) -> PauseState {
 /// Quick check — returns true if contract is currently paused
 pub fn is_paused(env: &Env) -> bool {
     get_pause_state(env).paused
+}
+
+/// Store pending upgrade (time-locked)
+pub fn set_pending_upgrade(env: &Env, pending: &PendingUpgrade) {
+    env.storage().instance().set(&PENDING_UPGRADE_KEY, pending);
+}
+
+/// Get pending upgrade, if any
+pub fn get_pending_upgrade(env: &Env) -> Option<PendingUpgrade> {
+    env.storage().instance().get(&PENDING_UPGRADE_KEY)
+}
+
+/// Remove pending upgrade
+pub fn clear_pending_upgrade(env: &Env) {
+    env.storage().instance().remove(&PENDING_UPGRADE_KEY);
+}
+
+/// Check if an upgrade is scheduled
+pub fn has_pending_upgrade(env: &Env) -> bool {
+    env.storage().instance().has(&PENDING_UPGRADE_KEY)
 }

--- a/contracts/shared/src/constants.rs
+++ b/contracts/shared/src/constants.rs
@@ -40,3 +40,6 @@ pub const VOTING_PERIOD: u64 = 604800;
 pub const MIN_APPROVAL_THRESHOLD: u32 = 5100;  // 51% minimum
 pub const MAX_APPROVAL_THRESHOLD: u32 = 10000; // 100% maximum
 pub const RESUME_TIME_DELAY: u64 = 86400; // 24 hours in seconds
+
+/// Minimum delay before a scheduled upgrade can be executed (48 hours)
+pub const UPGRADE_TIME_LOCK_SECS: u64 = 172800; // 48 * 3600

--- a/contracts/shared/src/errors.rs
+++ b/contracts/shared/src/errors.rs
@@ -25,7 +25,10 @@ pub enum Error {
     NotAValidator = 203,
     AlreadyVoted = 204,
     ContractPaused = 205,
-    ResumeTooEarly = 206, 
+    ResumeTooEarly = 206,
+    UpgradeNotScheduled = 207,
+    UpgradeTooEarly = 208,
+    UpgradeRequiresPause = 209, 
 
     // Distribution errors (300-399)
     InsufficientFunds = 300,

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -65,3 +65,8 @@ pub const BRIDGE_TX_CONFIRMED: Symbol = symbol_short!("tx_conf");
 pub const BRIDGE_TX_FAILED: Symbol = symbol_short!("tx_fail");
 pub const CONTRACT_PAUSED: Symbol = symbol_short!("esc_pause");
 pub const CONTRACT_RESUMED: Symbol = symbol_short!("esc_resum");
+
+// Upgrade events
+pub const UPGRADE_SCHEDULED: Symbol = symbol_short!("upg_sched");
+pub const UPGRADE_EXECUTED: Symbol = symbol_short!("upg_exec");
+pub const UPGRADE_CANCELLED: Symbol = symbol_short!("upg_canc");

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -235,3 +235,12 @@ pub struct PauseState {
     pub paused_at: u64,
     pub resume_not_before: u64,
 }
+
+/// Pending contract upgrade (time-locked). Used by ProjectLaunch and Escrow.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PendingUpgrade {
+    pub wasm_hash: Hash,
+    /// Ledger timestamp before which execute_upgrade will fail
+    pub execute_not_before: u64,
+}


### PR DESCRIPTION
Closes #33

---

## Description

Adds secure, time-locked upgrade support to **ProjectLaunch** and **Escrow** using Soroban’s native upgrade mechanism (no proxy pattern).

### What’s included

- **48-hour time-lock** – Upgrades are scheduled with `schedule_upgrade(admin, wasm_hash)` and can only be executed after `UPGRADE_TIME_LOCK_SECS` (172800 sec = 48h).
- **Pause required before execute** – `execute_upgrade(admin)` is only callable when the contract is paused (emergency pause before upgrades).
- **ProjectLaunch** – New: `pause`, `resume`, `get_is_paused`; `schedule_upgrade`, `execute_upgrade`, `cancel_upgrade`, `get_pending_upgrade`. `create_project` and `contribute` are blocked when paused.
- **Escrow** – New: `schedule_upgrade`, `execute_upgrade`, `cancel_upgrade`, `get_pending_upgrade`. Reuses existing pause; execute requires paused.
- **Shared** – `UPGRADE_TIME_LOCK_SECS`, `PendingUpgrade` type, errors (`UpgradeNotScheduled`, `UpgradeTooEarly`, `UpgradeRequiresPause`), events (`UPGRADE_SCHEDULED`, `UPGRADE_EXECUTED`, `UPGRADE_CANCELLED`).
- **Tests** – Upgrade and pause tests for both contracts (timelock, require-pause, admin-only, cancel).

### Flow

1. Admin calls `schedule_upgrade(admin, new_wasm_hash)` (WASM must be uploaded to the ledger).
2. Contract is paused via `pause(admin)`.
3. After 48 hours, admin calls `execute_upgrade(admin)`; contract replaces its WASM via `env.deployer().update_current_contract_wasm(wasm_hash)`. State is unchanged.
4. Admin calls `resume(admin)` after the resume delay (24h).

### Validation

- [x] Upgrade process has minimum 48-hour delay  
- [x] State variables remain intact after upgrade (same instance, only WASM replaced)  
- [x] Emergency pause required before execute_upgrade  
- [x] Access control: admin-only for schedule/execute/cancel  
- [x] Tests cover upgrade scenarios  

---