### PR TITLE
[136] Dispute Resolution Time-lock

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -42,3 +42,8 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
+
+[patch.crates-io]
+# Windows: published crate uses `crate-type = ["cdylib", "rlib"]`, which breaks `cargo test`
+# (PE >65k exports). Path crate is `rlib` only; WASM release builds for contracts are unaffected.
+soroban-token-sdk = { path = "patches/soroban-token-sdk" }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1165,15 +1165,6 @@ impl EscrowContract {
         env.events()
             .publish((DISPUTE_RESOLVED,), (dispute_id, resolution));
 
-        // Enforce immediately if max appeals reached
-        if dispute.appeal_count >= shared::constants::MAX_APPEALS as u32 {
-            dispute.status = DisputeStatus::FinalResolved;
-            set_dispute(&env, dispute_id, &dispute);
-            Self::enforce_resolution(&env, &dispute, &resolution)?;
-            env.events()
-                .publish((APPEAL_RESOLVED,), (dispute_id, resolution));
-        }
-
         Ok(())
     }
 
@@ -1197,7 +1188,21 @@ impl EscrowContract {
         }
 
         let current_time = env.ledger().timestamp();
-        if current_time <= dispute.created_at + shared::constants::APPEAL_WINDOW_PERIOD {
+        // Dispute resolution time-lock:
+        // - While appeals remain available, wait for the appeal window to elapse (and also satisfy the minimum lock).
+        // - Once max appeals are exhausted, enforcements still must wait for the resolution time-lock.
+        //
+        // `created_at` is reset in `tally_votes` and marks the start of these windows.
+        let required_delay = if dispute.appeal_count >= shared::constants::MAX_APPEALS as u32 {
+            shared::constants::RESOLUTION_TIME_LOCK
+        } else {
+            core::cmp::max(
+                shared::constants::RESOLUTION_TIME_LOCK,
+                shared::constants::APPEAL_WINDOW_PERIOD,
+            )
+        };
+
+        if current_time <= dispute.created_at + required_delay {
             return Err(Error::AppealWinCl); // Reusing for window still open
         }
 

--- a/contracts/patches/soroban-token-sdk/Cargo.toml
+++ b/contracts/patches/soroban-token-sdk/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "soroban-token-sdk"
+version = "21.7.7"
+description = "Soroban token SDK containing utilities for creating custom tokens on Soroban."
+homepage = "https://github.com/stellar/rs-soroban-sdk"
+repository = "https://github.com/stellar/rs-soroban-sdk"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+readme = "README.md"
+license = "Apache-2.0"
+edition = "2021"
+rust-version = "1.74.0"
+
+[lib]
+crate-type = ["rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = "21.7.7"

--- a/contracts/patches/soroban-token-sdk/README.md
+++ b/contracts/patches/soroban-token-sdk/README.md
@@ -1,0 +1,12 @@
+# rs-soroban-sdk
+Rust SDK for writing contracts for [Soroban].
+
+Soroban: https://soroban.stellar.org
+
+Docs: https://docs.rs/soroban-sdk
+
+[Soroban]: https://soroban.stellar.org
+
+## Contributing
+
+Contributing to the SDK? Read [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/contracts/patches/soroban-token-sdk/src/event.rs
+++ b/contracts/patches/soroban-token-sdk/src/event.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+pub struct Events {
+    env: Env,
+}
+
+impl Events {
+    #[inline(always)]
+    pub fn new(env: &Env) -> Events {
+        Events { env: env.clone() }
+    }
+
+    pub fn approve(&self, from: Address, to: Address, amount: i128, expiration_ledger: u32) {
+        let topics = (Symbol::new(&self.env, "approve"), from, to);
+        self.env
+            .events()
+            .publish(topics, (amount, expiration_ledger));
+    }
+
+    pub fn transfer(&self, from: Address, to: Address, amount: i128) {
+        let topics = (symbol_short!("transfer"), from, to);
+        self.env.events().publish(topics, amount);
+    }
+
+    pub fn mint(&self, admin: Address, to: Address, amount: i128) {
+        let topics = (symbol_short!("mint"), admin, to);
+        self.env.events().publish(topics, amount);
+    }
+
+    pub fn clawback(&self, admin: Address, from: Address, amount: i128) {
+        let topics = (symbol_short!("clawback"), admin, from);
+        self.env.events().publish(topics, amount);
+    }
+
+    pub fn set_authorized(&self, admin: Address, id: Address, authorize: bool) {
+        let topics = (Symbol::new(&self.env, "set_authorized"), admin, id);
+        self.env.events().publish(topics, authorize);
+    }
+
+    pub fn set_admin(&self, admin: Address, new_admin: Address) {
+        let topics = (symbol_short!("set_admin"), admin);
+        self.env.events().publish(topics, new_admin);
+    }
+
+    pub fn burn(&self, from: Address, amount: i128) {
+        let topics = (symbol_short!("burn"), from);
+        self.env.events().publish(topics, amount);
+    }
+}

--- a/contracts/patches/soroban-token-sdk/src/lib.rs
+++ b/contracts/patches/soroban-token-sdk/src/lib.rs
@@ -1,0 +1,26 @@
+#![no_std]
+
+use crate::event::Events;
+use crate::metadata::Metadata;
+use soroban_sdk::Env;
+
+pub mod event;
+pub mod metadata;
+
+#[derive(Clone)]
+pub struct TokenUtils(Env);
+
+impl TokenUtils {
+    #[inline(always)]
+    pub fn new(env: &Env) -> TokenUtils {
+        TokenUtils(env.clone())
+    }
+
+    pub fn metadata(&self) -> Metadata {
+        Metadata::new(&self.0)
+    }
+
+    pub fn events(&self) -> Events {
+        Events::new(&self.0)
+    }
+}

--- a/contracts/patches/soroban-token-sdk/src/metadata.rs
+++ b/contracts/patches/soroban-token-sdk/src/metadata.rs
@@ -1,0 +1,35 @@
+use soroban_sdk::{contracttype, symbol_short, unwrap::UnwrapOptimized, Env, String, Symbol};
+
+const METADATA_KEY: Symbol = symbol_short!("METADATA");
+
+#[derive(Clone)]
+#[contracttype]
+pub struct TokenMetadata {
+    pub decimal: u32,
+    pub name: String,
+    pub symbol: String,
+}
+
+pub struct Metadata {
+    env: Env,
+}
+
+impl Metadata {
+    pub fn new(env: &Env) -> Metadata {
+        Metadata { env: env.clone() }
+    }
+
+    #[inline(always)]
+    pub fn set_metadata(&self, metadata: &TokenMetadata) {
+        self.env.storage().instance().set(&METADATA_KEY, metadata);
+    }
+
+    #[inline(always)]
+    pub fn get_metadata(&self) -> TokenMetadata {
+        self.env
+            .storage()
+            .instance()
+            .get(&METADATA_KEY)
+            .unwrap_optimized()
+    }
+}

--- a/contracts/shared/src/constants.rs
+++ b/contracts/shared/src/constants.rs
@@ -59,6 +59,9 @@ pub const VOTING_REVEAL_PERIOD: u64 = 172800;
 /// Appeal window period (e.g., 5 days in seconds)
 pub const APPEAL_WINDOW_PERIOD: u64 = 432000;
 
+/// Minimum time-lock before a jury dispute outcome can be enforced on-chain (seconds)
+pub const RESOLUTION_TIME_LOCK: u64 = 259200; // 72 hours
+
 /// Flat fee for filing an appeal
 pub const APPEAL_FEE: i128 = 1_000_000_000;
 


### PR DESCRIPTION
Closes 136

Closes #136

### Changes
- Add \RESOLUTION_TIME_LOCK\ (72h) in \contracts/shared\.
- \execute_resolution\ enforces minimum delay after \	ally_votes\ (uses \max(lock, APPEAL_WINDOW_PERIOD)\ while appeals remain; lock only after max appeals).
- Vendor \soroban-token-sdk\ as \lib\-only via \[patch.crates-io]\ so Windows \cargo test\ avoids the PE export limit.

### Tests
- \cargo test -p escrow\ (45 tests)
- \cargo build --release --target wasm32-unknown-unknown -p escrow\
