### PR TITLE
 feat: implement social sharing link shortener and viral growth tracking

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Project {
   // Relations
   contributions Contribution[]
   milestones    Milestone[]
+  shortlinks    Shortlink[]
 
   @@map("projects")
 }
@@ -311,4 +312,19 @@ model TokenPrice {
 
   @@index([symbol, fetchedAt])
   @@map("token_prices")
+}
+
+model Shortlink {
+  id        String   @id @default(cuid())
+  code      String   @unique
+  url       String
+  projectId String?  @map("project_id")
+  project   Project? @relation(fields: [projectId], references: [id])
+  clicks    Int      @default(0)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([projectId])
+  @@index([clicks(sort: Desc)])
+  @@map("shortlinks")
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { ProjectModule } from './project/project.module';
 import { StellarModule } from './stellar/stellar.module';
 import { OracleModule } from './oracle/oracle.module';
 import { GraphQLRateLimitModule } from './graphql/graphql-rate-limit.module';
+import { ShortlinkModule } from './shortlink/shortlink.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { GraphQLRateLimitModule } from './graphql/graphql-rate-limit.module';
     VerificationModule,
     ProjectModule,
     OracleModule,
+    ShortlinkModule,
   ],
   controllers: [AppController, UserController],
   providers: [AppService],

--- a/backend/src/services/shortlink.service.ts
+++ b/backend/src/services/shortlink.service.ts
@@ -1,0 +1,94 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class ShortlinkService {
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Generate a unique short code
+   */
+  private generateShortCode(): string {
+    return Math.random().toString(36).substring(2, 8);
+  }
+
+  /**
+   * Create a new shortlink
+   */
+  async createShortlink(url: string, projectId?: string) {
+    let code = this.generateShortCode();
+    
+    // Ensure uniqueness
+    let existing = await this.prisma.shortlink.findUnique({ where: { code } });
+    while (existing) {
+      code = this.generateShortCode();
+      existing = await this.prisma.shortlink.findUnique({ where: { code } });
+    }
+
+    return this.prisma.shortlink.create({
+      data: {
+        code,
+        url,
+        projectId,
+      },
+    });
+  }
+
+  /**
+   * Track a click and return the original URL
+   */
+  async getAndTrack(code: string) {
+    const shortlink = await this.prisma.shortlink.findUnique({
+      where: { code },
+    });
+
+    if (!shortlink) {
+      throw new NotFoundException('Shortlink not found');
+    }
+
+    // Increment click asynchronously (fire-and-forget to avoid blocking the redirect)
+    this.prisma.shortlink.update({
+      where: { id: shortlink.id },
+      data: { clicks: { increment: 1 } },
+    }).catch(err => console.error('Error tracking shortlink click:', err));
+
+    return shortlink.url;
+  }
+
+  /**
+   * Get trending projects based on shortlink clicks
+   */
+  async getTrendingProjects(limit: number = 10) {
+    // Group by projectId and sum clicks
+    const trendingShortlinks = await this.prisma.shortlink.groupBy({
+      by: ['projectId'],
+      _sum: {
+        clicks: true,
+      },
+      where: {
+        projectId: { not: null },
+      },
+      orderBy: {
+        _sum: {
+          clicks: 'desc',
+        },
+      },
+      take: limit,
+    });
+
+    // Fetch the actual projects
+    const projectIds = trendingShortlinks.map(s => s.projectId as string);
+    const projects = await this.prisma.project.findMany({
+      where: { id: { in: projectIds } },
+    });
+
+    // Map the results back to include the total clicks
+    return trendingShortlinks.map(trend => {
+      const project = projects.find(p => p.id === trend.projectId);
+      return {
+        project,
+        totalClicks: trend._sum.clicks || 0,
+      };
+    });
+  }
+}

--- a/backend/src/shortlink/shortlink.controller.ts
+++ b/backend/src/shortlink/shortlink.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Post, Get, Body, Param, Res, Redirect } from '@nestjs/common';
+import { ShortlinkService } from '../services/shortlink.service';
+import { Response } from 'express';
+
+@Controller()
+export class ShortlinkController {
+  constructor(private readonly shortlinkService: ShortlinkService) {}
+
+  @Post('api/shortlink')
+  async createShortlink(@Body() body: { url: string; projectId?: string }) {
+    return this.shortlinkService.createShortlink(body.url, body.projectId);
+  }
+
+  @Get('api/shortlink/trending')
+  async getTrendingProjects() {
+    return this.shortlinkService.getTrendingProjects(10);
+  }
+
+  // Redirect endpoint for the short code
+  // Example: GET /s/xyz -> Redirects to the original URL
+  @Get('s/:code')
+  async redirectShortlink(@Param('code') code: string, @Res() res: Response) {
+    const originalUrl = await this.shortlinkService.getAndTrack(code);
+    return res.redirect(originalUrl);
+  }
+}

--- a/backend/src/shortlink/shortlink.module.ts
+++ b/backend/src/shortlink/shortlink.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ShortlinkController } from './shortlink.controller';
+import { ShortlinkService } from '../services/shortlink.service';
+import { DatabaseModule } from '../database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [ShortlinkController],
+  providers: [ShortlinkService],
+  exports: [ShortlinkService],
+})
+export class ShortlinkModule {}


### PR DESCRIPTION
Closes #436

---


This PR introduces a minimalist link-shortening service to help track viral growth on social media. Long project URLs are notoriously difficult to share on platforms like Twitter or via SMS, which hinders organic discovery. This feature solves that by generating short, shareable links and tracking click-through rates (CTR).
I added:
-Shortlink generation**: `POST /api/shortlink` generates a random, unique shortcode for any given URL.
- **Click-through tracking**: `GET /s/:code` intercepts the user, increments the click counter asynchronously for performance, and redirects them to the original destination.
- **Trending analytics**: `GET /api/shortlink/trending` surfaces the top projects sorted by real-time click volume.

 