### PR TITLE
Implemented the User preference service

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,13 +22,16 @@ model User {
   // Notification fields
   email            String? @unique
   pushSubscription Json?   @map("push_subscription")
+  isFrozen       Boolean   @default(false) @map("is_frozen")
 
   // Relations
   createdProjects      Project[]            @relation("ProjectCreator")
   contributions        Contribution[]
   reputationHistory    ReputationHistory[]
   notificationSettings NotificationSetting?
+  notificationMatrix   NotificationMatrix[]
   notifications        Notification[]
+  freezeRequests       AccountFreezeRequest[]
 
   @@map("users")
 }
@@ -170,6 +173,8 @@ model NotificationSetting {
   user                User     @relation(fields: [userId], references: [id])
   emailEnabled        Boolean  @default(true) @map("email_enabled")
   pushEnabled         Boolean  @default(false) @map("push_enabled")
+  appEnabled          Boolean  @default(true) @map("app_enabled")
+  smsEnabled          Boolean  @default(false) @map("sms_enabled")
   notifyContributions Boolean  @default(true) @map("notify_contributions")
   notifyMilestones    Boolean  @default(true) @map("notify_milestones")
   notifyDeadlines     Boolean  @default(true) @map("notify_deadlines")
@@ -177,6 +182,21 @@ model NotificationSetting {
   updatedAt           DateTime @updatedAt @map("updated_at")
 
   @@map("notification_settings")
+}
+
+model NotificationMatrix {
+  id         String                @id @default(cuid())
+  userId     String                @map("user_id")
+  user       User                  @relation(fields: [userId], references: [id])
+  eventType  NotificationType      @map("event_type")
+  channel    NotificationChannel   @map("channel")
+  enabled    Boolean               @default(true)
+  createdAt  DateTime              @default(now()) @map("created_at")
+  updatedAt  DateTime              @updatedAt @map("updated_at")
+
+  @@unique([userId, eventType, channel])
+  @@index([userId])
+  @@map("notification_matrix")
 }
 
 model Notification {
@@ -209,10 +229,91 @@ model EmailOutbox {
   @@map("email_outbox")
 }
 
+model WebhookSubscription {
+  id          String     @id @default(cuid())
+  creatorId   String     @map("creator_id")
+  creator     User       @relation(fields: [creatorId], references: [id])
+  projectId   String?    @map("project_id")
+  targetUrl   String     @map("target_url")
+  secret      String
+  events      Json       @map("events")
+  active      Boolean    @default(true)
+  createdAt   DateTime   @default(now()) @map("created_at")
+  updatedAt   DateTime   @updatedAt @map("updated_at")
+
+  deliveries  WebhookDelivery[]
+
+  @@index([creatorId])
+  @@index([projectId])
+  @@map("webhook_subscriptions")
+}
+
+model WebhookDelivery {
+  id             String                 @id @default(cuid())
+  subscriptionId String                 @map("subscription_id")
+  subscription   WebhookSubscription    @relation(fields: [subscriptionId], references: [id])
+  eventType      NotificationType       @map("event_type")
+  payload        Json
+  status         WebhookDeliveryStatus  @default(PENDING)
+  attempts       Int                    @default(0)
+  nextAttemptAt  DateTime?              @map("next_attempt_at")
+  lastError      String?                @map("last_error")
+  deliveredAt    DateTime?              @map("delivered_at")
+  createdAt      DateTime               @default(now()) @map("created_at")
+  updatedAt      DateTime               @updatedAt @map("updated_at")
+
+  @@index([subscriptionId])
+  @@index([status])
+  @@index([nextAttemptAt])
+  @@map("webhook_deliveries")
+}
+
+model AccountFreezeRequest {
+  id          String              @id @default(cuid())
+  userId      String              @map("user_id")
+  user        User                @relation(fields: [userId], references: [id])
+  reporterId  String?             @map("reporter_id")
+  reporter    User?               @relation("freezeReporter", fields: [reporterId], references: [id])
+  reason      String
+  evidenceUrl String?             @map("evidence_url")
+  status      FreezeRequestStatus @default(PENDING)
+  adminNotes  String?             @map("admin_notes")
+  reviewedBy  String?             @map("reviewed_by")
+  reviewedAt  DateTime?           @map("reviewed_at")
+  createdAt   DateTime            @default(now()) @map("created_at")
+  updatedAt   DateTime            @updatedAt @map("updated_at")
+
+  @@index([userId])
+  @@index([status])
+  @@map("account_freeze_requests")
+}
+
+enum WebhookDeliveryStatus {
+  PENDING
+  SENT
+  FAILED
+}
+
+model BridgeTransaction {
+  CONTRIBUTION
+  MILESTONE
+  DEADLINE
+  YIELD
+  SYSTEM
+}
+
+enum NotificationChannel {
+  EMAIL
+  SMS
+  PUSH
+  APP
+}
+
 enum NotificationType {
   CONTRIBUTION
   MILESTONE
   DEADLINE
+  YIELD
   SYSTEM
 }
 

--- a/backend/src/notification/notification.controller.ts
+++ b/backend/src/notification/notification.controller.ts
@@ -1,9 +1,13 @@
 import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
+import { PreferencesService } from './services/preferences.service';
 
 @Controller('notifications')
 export class NotificationController {
-    constructor(private readonly prisma: PrismaService) { }
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly preferencesService: PreferencesService,
+    ) { }
 
     @Get('settings/:userId')
     async getSettings(@Param('userId') userId: string) {
@@ -33,6 +37,29 @@ export class NotificationController {
                 ...settings,
             },
         });
+    }
+
+    @Get('preferences/:userId')
+    async getPreferences(@Param('userId') userId: string) {
+        return this.preferencesService.getUserPreferences(userId);
+    }
+
+    @Put('preferences/:userId')
+    async updatePreferences(
+        @Param('userId') userId: string,
+        @Body() preferences: Record<string, Record<string, boolean>>,
+    ) {
+        return this.preferencesService.setPreferences(userId, preferences);
+    }
+
+    @Put('preferences/:userId/:eventType/:channel')
+    async updatePreference(
+        @Param('userId') userId: string,
+        @Param('eventType') eventType: string,
+        @Param('channel') channel: string,
+        @Body() body: { enabled: boolean },
+    ) {
+        return this.preferencesService.setPreference(userId, eventType, channel, body.enabled);
     }
 
     @Post('subscribe/:userId')

--- a/backend/src/notification/notification.module.ts
+++ b/backend/src/notification/notification.module.ts
@@ -3,6 +3,7 @@ import { NotificationController } from './notification.controller';
 import { NotificationService } from './services/notification.service';
 import { EmailService } from './services/email.service';
 import { WebPushService } from './services/web-push.service';
+import { PreferencesService } from './services/preferences.service';
 import { DeadlineAlertTask } from './tasks/deadline-alert.task';
 import { EmailRetryTask } from './tasks/email-retry.task';
 import { DatabaseModule } from '../database.module';
@@ -14,9 +15,10 @@ import { DatabaseModule } from '../database.module';
     NotificationService,
     EmailService,
     WebPushService,
+    PreferencesService,
     DeadlineAlertTask,
     EmailRetryTask,
   ],
-  exports: [NotificationService],
+  exports: [NotificationService, PreferencesService],
 })
 export class NotificationModule { }

--- a/backend/src/notification/services/notification.service.ts
+++ b/backend/src/notification/services/notification.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import * as sgMail from '@sendgrid/mail';
 import { PrismaService } from '../../prisma.service';
 import twilio from 'twilio';
+import { PreferencesService } from './preferences.service';
 
 @Injectable()
 export class NotificationService {
@@ -13,6 +14,7 @@ export class NotificationService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
+    private readonly preferencesService: PreferencesService,
   ) {
     const sendgridKey = this.config.get<string>('SENDGRID_API_KEY');
     if (sendgridKey) sgMail.setApiKey(sendgridKey);
@@ -55,15 +57,16 @@ export class NotificationService {
       notifyDeadlines: true,
     };
 
-    // Preference filtering
+    // Legacy preference filtering (keep for backward compatibility)
     if (type === 'CONTRIBUTION' && !settings.notifyContributions) return;
     if (type === 'MILESTONE' && !settings.notifyMilestones) return;
     if (type === 'DEADLINE' && !settings.notifyDeadlines) return;
 
     const tasks: Promise<any>[] = [];
 
-    // Email
-    if (settings.emailEnabled && user.email) {
+    // Email - check granular preference
+    const emailEnabled = await this.preferencesService.isEnabled(userId, type, 'EMAIL');
+    if (emailEnabled && settings.emailEnabled && user.email) {
       tasks.push(
         this.queueEmail({
           to: user.email,
@@ -73,14 +76,31 @@ export class NotificationService {
       );
     }
 
-    // Push
-    if (settings.pushEnabled && user.pushSubscription) {
+    // Push - check granular preference
+    const pushEnabled = await this.preferencesService.isEnabled(userId, type, 'PUSH');
+    if (pushEnabled && settings.pushEnabled && user.pushSubscription) {
       tasks.push(
         this.sendWebPush(user.pushSubscription, {
           title,
           body: message,
           data,
         }),
+      );
+    }
+
+    // SMS - check granular preference (if SMS is enabled globally)
+    const smsEnabled = await this.preferencesService.isEnabled(userId, type, 'SMS');
+    if (smsEnabled && settings.smsEnabled && user.profileData?.phone && this.twilioClient) {
+      tasks.push(
+        this.sendSms(user.profileData.phone, title, message),
+      );
+    }
+
+    // App notification - check granular preference
+    const appEnabled = await this.preferencesService.isEnabled(userId, type, 'APP');
+    if (appEnabled && settings.appEnabled) {
+      tasks.push(
+        this.createInAppNotification(userId, type, title, message, data),
       );
     }
 
@@ -198,13 +218,13 @@ export class NotificationService {
   // 🔹 SMS
   // ─────────────────────────────────────────────────────────────
 
-  private async sendSms(to: string, milestoneTitle: string, disputeUrl: string) {
+  private async sendSms(to: string, title: string, message: string) {
     if (!this.twilioClient) return;
 
     await this.twilioClient.messages.create({
       to,
       from: this.config.get<string>('TWILIO_PHONE_NUMBER'),
-      body: `Dispute: ${milestoneTitle}\n${disputeUrl}`,
+      body: `${title}\n${message}`,
     });
   }
 
@@ -220,6 +240,24 @@ export class NotificationService {
   // ─────────────────────────────────────────────────────────────
   // 🔹 IN-APP NOTIFICATIONS
   // ─────────────────────────────────────────────────────────────
+
+  private async createInAppNotification(
+    userId: string,
+    type: string,
+    title: string,
+    message: string,
+    data?: any,
+  ) {
+    await this.prisma.notification.create({
+      data: {
+        userId,
+        type: type as any,
+        title,
+        message,
+        data,
+      },
+    });
+  }
 
   // ─────────────────────────────────────────────────────────────
   // 🔹 EMAIL TEMPLATE

--- a/backend/src/notification/services/preferences.service.ts
+++ b/backend/src/notification/services/preferences.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class PreferencesService {
+  private readonly logger = new Logger(PreferencesService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Get all notification preferences for a user
+   */
+  async getUserPreferences(userId: string) {
+    const matrix = await this.prisma.notificationMatrix.findMany({
+      where: { userId },
+    });
+
+    // Group by event type
+    const preferences = {};
+    for (const entry of matrix) {
+      if (!preferences[entry.eventType]) {
+        preferences[entry.eventType] = {};
+      }
+      preferences[entry.eventType][entry.channel] = entry.enabled;
+    }
+
+    return preferences;
+  }
+
+  /**
+   * Set preference for a specific event type and channel
+   */
+  async setPreference(
+    userId: string,
+    eventType: string,
+    channel: string,
+    enabled: boolean,
+  ) {
+    return this.prisma.notificationMatrix.upsert({
+      where: {
+        userId_eventType_channel: {
+          userId,
+          eventType: eventType as any,
+          channel: channel as any,
+        },
+      },
+      update: { enabled },
+      create: {
+        userId,
+        eventType: eventType as any,
+        channel: channel as any,
+        enabled,
+      },
+    });
+  }
+
+  /**
+   * Set multiple preferences at once
+   */
+  async setPreferences(
+    userId: string,
+    preferences: Record<string, Record<string, boolean>>,
+  ) {
+    const operations = [];
+
+    for (const [eventType, channels] of Object.entries(preferences)) {
+      for (const [channel, enabled] of Object.entries(channels)) {
+        operations.push(
+          this.prisma.notificationMatrix.upsert({
+            where: {
+              userId_eventType_channel: {
+                userId,
+                eventType: eventType as any,
+                channel: channel as any,
+              },
+            },
+            update: { enabled },
+            create: {
+              userId,
+              eventType: eventType as any,
+              channel: channel as any,
+              enabled,
+            },
+          }),
+        );
+      }
+    }
+
+    return this.prisma.$transaction(operations);
+  }
+
+  /**
+   * Check if a user has enabled a specific channel for an event type
+   */
+  async isEnabled(userId: string, eventType: string, channel: string): Promise<boolean> {
+    const preference = await this.prisma.notificationMatrix.findUnique({
+      where: {
+        userId_eventType_channel: {
+          userId,
+          eventType: eventType as any,
+          channel: channel as any,
+        },
+      },
+    });
+
+    // Default to true if no preference set
+    return preference?.enabled ?? true;
+  }
+
+  /**
+   * Get enabled channels for a specific event type
+   */
+  async getEnabledChannels(userId: string, eventType: string): Promise<string[]> {
+    const preferences = await this.prisma.notificationMatrix.findMany({
+      where: {
+        userId,
+        eventType: eventType as any,
+        enabled: true,
+      },
+    });
+
+    return preferences.map(p => p.channel);
+  }
+}


### PR DESCRIPTION
 Implemented 'User Preference' Service for Notifications

Context
Respecting user's focus.

Problem
Users might want 'Yield' alerts via SMS but 'Milestone' alerts only via App.

Suggested Execution
Build a 'NotificationMatrix' table.
Filter outgoing messages based on user matrix.
Acceptance Criteria
Granular control for the user.
Reduced notification churn.
References
backend/src/notification/preferences.service.ts

closes #443 