### PR TITLE
Emegerncy freeze

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,13 +22,16 @@ model User {
   // Notification fields
   email            String? @unique
   pushSubscription Json?   @map("push_subscription")
+  isFrozen       Boolean   @default(false) @map("is_frozen")
 
   // Relations
   createdProjects      Project[]            @relation("ProjectCreator")
   contributions        Contribution[]
   reputationHistory    ReputationHistory[]
   notificationSettings NotificationSetting?
+  notificationMatrix   NotificationMatrix[]
   notifications        Notification[]
+  freezeRequests       AccountFreezeRequest[]
 
   @@map("users")
 }
@@ -170,6 +173,8 @@ model NotificationSetting {
   user                User     @relation(fields: [userId], references: [id])
   emailEnabled        Boolean  @default(true) @map("email_enabled")
   pushEnabled         Boolean  @default(false) @map("push_enabled")
+  appEnabled          Boolean  @default(true) @map("app_enabled")
+  smsEnabled          Boolean  @default(false) @map("sms_enabled")
   notifyContributions Boolean  @default(true) @map("notify_contributions")
   notifyMilestones    Boolean  @default(true) @map("notify_milestones")
   notifyDeadlines     Boolean  @default(true) @map("notify_deadlines")
@@ -177,6 +182,21 @@ model NotificationSetting {
   updatedAt           DateTime @updatedAt @map("updated_at")
 
   @@map("notification_settings")
+}
+
+model NotificationMatrix {
+  id         String                @id @default(cuid())
+  userId     String                @map("user_id")
+  user       User                  @relation(fields: [userId], references: [id])
+  eventType  NotificationType      @map("event_type")
+  channel    NotificationChannel   @map("channel")
+  enabled    Boolean               @default(true)
+  createdAt  DateTime              @default(now()) @map("created_at")
+  updatedAt  DateTime              @updatedAt @map("updated_at")
+
+  @@unique([userId, eventType, channel])
+  @@index([userId])
+  @@map("notification_matrix")
 }
 
 model Notification {
@@ -209,10 +229,91 @@ model EmailOutbox {
   @@map("email_outbox")
 }
 
+model WebhookSubscription {
+  id          String     @id @default(cuid())
+  creatorId   String     @map("creator_id")
+  creator     User       @relation(fields: [creatorId], references: [id])
+  projectId   String?    @map("project_id")
+  targetUrl   String     @map("target_url")
+  secret      String
+  events      Json       @map("events")
+  active      Boolean    @default(true)
+  createdAt   DateTime   @default(now()) @map("created_at")
+  updatedAt   DateTime   @updatedAt @map("updated_at")
+
+  deliveries  WebhookDelivery[]
+
+  @@index([creatorId])
+  @@index([projectId])
+  @@map("webhook_subscriptions")
+}
+
+model WebhookDelivery {
+  id             String                 @id @default(cuid())
+  subscriptionId String                 @map("subscription_id")
+  subscription   WebhookSubscription    @relation(fields: [subscriptionId], references: [id])
+  eventType      NotificationType       @map("event_type")
+  payload        Json
+  status         WebhookDeliveryStatus  @default(PENDING)
+  attempts       Int                    @default(0)
+  nextAttemptAt  DateTime?              @map("next_attempt_at")
+  lastError      String?                @map("last_error")
+  deliveredAt    DateTime?              @map("delivered_at")
+  createdAt      DateTime               @default(now()) @map("created_at")
+  updatedAt      DateTime               @updatedAt @map("updated_at")
+
+  @@index([subscriptionId])
+  @@index([status])
+  @@index([nextAttemptAt])
+  @@map("webhook_deliveries")
+}
+
+model AccountFreezeRequest {
+  id          String              @id @default(cuid())
+  userId      String              @map("user_id")
+  user        User                @relation(fields: [userId], references: [id])
+  reporterId  String?             @map("reporter_id")
+  reporter    User?               @relation("freezeReporter", fields: [reporterId], references: [id])
+  reason      String
+  evidenceUrl String?             @map("evidence_url")
+  status      FreezeRequestStatus @default(PENDING)
+  adminNotes  String?             @map("admin_notes")
+  reviewedBy  String?             @map("reviewed_by")
+  reviewedAt  DateTime?           @map("reviewed_at")
+  createdAt   DateTime            @default(now()) @map("created_at")
+  updatedAt   DateTime            @updatedAt @map("updated_at")
+
+  @@index([userId])
+  @@index([status])
+  @@map("account_freeze_requests")
+}
+
+enum WebhookDeliveryStatus {
+  PENDING
+  SENT
+  FAILED
+}
+
+model BridgeTransaction {
+  CONTRIBUTION
+  MILESTONE
+  DEADLINE
+  YIELD
+  SYSTEM
+}
+
+enum NotificationChannel {
+  EMAIL
+  SMS
+  PUSH
+  APP
+}
+
 enum NotificationType {
   CONTRIBUTION
   MILESTONE
   DEADLINE
+  YIELD
   SYSTEM
 }
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,7 +3,6 @@ import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { AppController } from './app.controller';
-import { UserController } from './user.controller';
 import { AppService } from './app.service';
 import { validateEnv } from './config/env.validation';
 import { ReputationModule } from './reputation/reputation.module';
@@ -19,6 +18,7 @@ import { ProjectModule } from './project/project.module';
 import { StellarModule } from './stellar/stellar.module';
 import { OracleModule } from './oracle/oracle.module';
 import { GraphQLRateLimitModule } from './graphql/graphql-rate-limit.module';
+import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
@@ -45,8 +45,9 @@ import { GraphQLRateLimitModule } from './graphql/graphql-rate-limit.module';
     VerificationModule,
     ProjectModule,
     OracleModule,
+    UserModule,
   ],
-  controllers: [AppController, UserController],
+  controllers: [AppController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/notification/notification.controller.ts
+++ b/backend/src/notification/notification.controller.ts
@@ -1,9 +1,13 @@
 import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
+import { PreferencesService } from './services/preferences.service';
 
 @Controller('notifications')
 export class NotificationController {
-    constructor(private readonly prisma: PrismaService) { }
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly preferencesService: PreferencesService,
+    ) { }
 
     @Get('settings/:userId')
     async getSettings(@Param('userId') userId: string) {
@@ -33,6 +37,29 @@ export class NotificationController {
                 ...settings,
             },
         });
+    }
+
+    @Get('preferences/:userId')
+    async getPreferences(@Param('userId') userId: string) {
+        return this.preferencesService.getUserPreferences(userId);
+    }
+
+    @Put('preferences/:userId')
+    async updatePreferences(
+        @Param('userId') userId: string,
+        @Body() preferences: Record<string, Record<string, boolean>>,
+    ) {
+        return this.preferencesService.setPreferences(userId, preferences);
+    }
+
+    @Put('preferences/:userId/:eventType/:channel')
+    async updatePreference(
+        @Param('userId') userId: string,
+        @Param('eventType') eventType: string,
+        @Param('channel') channel: string,
+        @Body() body: { enabled: boolean },
+    ) {
+        return this.preferencesService.setPreference(userId, eventType, channel, body.enabled);
     }
 
     @Post('subscribe/:userId')

--- a/backend/src/notification/notification.module.ts
+++ b/backend/src/notification/notification.module.ts
@@ -3,6 +3,7 @@ import { NotificationController } from './notification.controller';
 import { NotificationService } from './services/notification.service';
 import { EmailService } from './services/email.service';
 import { WebPushService } from './services/web-push.service';
+import { PreferencesService } from './services/preferences.service';
 import { DeadlineAlertTask } from './tasks/deadline-alert.task';
 import { EmailRetryTask } from './tasks/email-retry.task';
 import { DatabaseModule } from '../database.module';
@@ -14,9 +15,10 @@ import { DatabaseModule } from '../database.module';
     NotificationService,
     EmailService,
     WebPushService,
+    PreferencesService,
     DeadlineAlertTask,
     EmailRetryTask,
   ],
-  exports: [NotificationService],
+  exports: [NotificationService, PreferencesService],
 })
 export class NotificationModule { }

--- a/backend/src/notification/services/notification.service.ts
+++ b/backend/src/notification/services/notification.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import * as sgMail from '@sendgrid/mail';
 import { PrismaService } from '../../prisma.service';
 import twilio from 'twilio';
+import { PreferencesService } from './preferences.service';
 
 @Injectable()
 export class NotificationService {
@@ -13,6 +14,7 @@ export class NotificationService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
+    private readonly preferencesService: PreferencesService,
   ) {
     const sendgridKey = this.config.get<string>('SENDGRID_API_KEY');
     if (sendgridKey) sgMail.setApiKey(sendgridKey);
@@ -55,15 +57,16 @@ export class NotificationService {
       notifyDeadlines: true,
     };
 
-    // Preference filtering
+    // Legacy preference filtering (keep for backward compatibility)
     if (type === 'CONTRIBUTION' && !settings.notifyContributions) return;
     if (type === 'MILESTONE' && !settings.notifyMilestones) return;
     if (type === 'DEADLINE' && !settings.notifyDeadlines) return;
 
     const tasks: Promise<any>[] = [];
 
-    // Email
-    if (settings.emailEnabled && user.email) {
+    // Email - check granular preference
+    const emailEnabled = await this.preferencesService.isEnabled(userId, type, 'EMAIL');
+    if (emailEnabled && settings.emailEnabled && user.email) {
       tasks.push(
         this.queueEmail({
           to: user.email,
@@ -73,14 +76,31 @@ export class NotificationService {
       );
     }
 
-    // Push
-    if (settings.pushEnabled && user.pushSubscription) {
+    // Push - check granular preference
+    const pushEnabled = await this.preferencesService.isEnabled(userId, type, 'PUSH');
+    if (pushEnabled && settings.pushEnabled && user.pushSubscription) {
       tasks.push(
         this.sendWebPush(user.pushSubscription, {
           title,
           body: message,
           data,
         }),
+      );
+    }
+
+    // SMS - check granular preference (if SMS is enabled globally)
+    const smsEnabled = await this.preferencesService.isEnabled(userId, type, 'SMS');
+    if (smsEnabled && settings.smsEnabled && user.profileData?.phone && this.twilioClient) {
+      tasks.push(
+        this.sendSms(user.profileData.phone, title, message),
+      );
+    }
+
+    // App notification - check granular preference
+    const appEnabled = await this.preferencesService.isEnabled(userId, type, 'APP');
+    if (appEnabled && settings.appEnabled) {
+      tasks.push(
+        this.createInAppNotification(userId, type, title, message, data),
       );
     }
 
@@ -198,13 +218,13 @@ export class NotificationService {
   // 🔹 SMS
   // ─────────────────────────────────────────────────────────────
 
-  private async sendSms(to: string, milestoneTitle: string, disputeUrl: string) {
+  private async sendSms(to: string, title: string, message: string) {
     if (!this.twilioClient) return;
 
     await this.twilioClient.messages.create({
       to,
       from: this.config.get<string>('TWILIO_PHONE_NUMBER'),
-      body: `Dispute: ${milestoneTitle}\n${disputeUrl}`,
+      body: `${title}\n${message}`,
     });
   }
 
@@ -220,6 +240,24 @@ export class NotificationService {
   // ─────────────────────────────────────────────────────────────
   // 🔹 IN-APP NOTIFICATIONS
   // ─────────────────────────────────────────────────────────────
+
+  private async createInAppNotification(
+    userId: string,
+    type: string,
+    title: string,
+    message: string,
+    data?: any,
+  ) {
+    await this.prisma.notification.create({
+      data: {
+        userId,
+        type: type as any,
+        title,
+        message,
+        data,
+      },
+    });
+  }
 
   // ─────────────────────────────────────────────────────────────
   // 🔹 EMAIL TEMPLATE

--- a/backend/src/notification/services/preferences.service.ts
+++ b/backend/src/notification/services/preferences.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class PreferencesService {
+  private readonly logger = new Logger(PreferencesService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Get all notification preferences for a user
+   */
+  async getUserPreferences(userId: string) {
+    const matrix = await this.prisma.notificationMatrix.findMany({
+      where: { userId },
+    });
+
+    // Group by event type
+    const preferences = {};
+    for (const entry of matrix) {
+      if (!preferences[entry.eventType]) {
+        preferences[entry.eventType] = {};
+      }
+      preferences[entry.eventType][entry.channel] = entry.enabled;
+    }
+
+    return preferences;
+  }
+
+  /**
+   * Set preference for a specific event type and channel
+   */
+  async setPreference(
+    userId: string,
+    eventType: string,
+    channel: string,
+    enabled: boolean,
+  ) {
+    return this.prisma.notificationMatrix.upsert({
+      where: {
+        userId_eventType_channel: {
+          userId,
+          eventType: eventType as any,
+          channel: channel as any,
+        },
+      },
+      update: { enabled },
+      create: {
+        userId,
+        eventType: eventType as any,
+        channel: channel as any,
+        enabled,
+      },
+    });
+  }
+
+  /**
+   * Set multiple preferences at once
+   */
+  async setPreferences(
+    userId: string,
+    preferences: Record<string, Record<string, boolean>>,
+  ) {
+    const operations = [];
+
+    for (const [eventType, channels] of Object.entries(preferences)) {
+      for (const [channel, enabled] of Object.entries(channels)) {
+        operations.push(
+          this.prisma.notificationMatrix.upsert({
+            where: {
+              userId_eventType_channel: {
+                userId,
+                eventType: eventType as any,
+                channel: channel as any,
+              },
+            },
+            update: { enabled },
+            create: {
+              userId,
+              eventType: eventType as any,
+              channel: channel as any,
+              enabled,
+            },
+          }),
+        );
+      }
+    }
+
+    return this.prisma.$transaction(operations);
+  }
+
+  /**
+   * Check if a user has enabled a specific channel for an event type
+   */
+  async isEnabled(userId: string, eventType: string, channel: string): Promise<boolean> {
+    const preference = await this.prisma.notificationMatrix.findUnique({
+      where: {
+        userId_eventType_channel: {
+          userId,
+          eventType: eventType as any,
+          channel: channel as any,
+        },
+      },
+    });
+
+    // Default to true if no preference set
+    return preference?.enabled ?? true;
+  }
+
+  /**
+   * Get enabled channels for a specific event type
+   */
+  async getEnabledChannels(userId: string, eventType: string): Promise<string[]> {
+    const preferences = await this.prisma.notificationMatrix.findMany({
+      where: {
+        userId,
+        eventType: eventType as any,
+        enabled: true,
+      },
+    });
+
+    return preferences.map(p => p.channel);
+  }
+}

--- a/backend/src/user.controller.ts
+++ b/backend/src/user.controller.ts
@@ -1,9 +1,15 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Post, Put, Body, UseGuards } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
+import { AccountSecurityService } from './account-security.service';
+// TODO: Add admin guard
+// import { AdminGuard } from './guards/admin.guard';
 
 @Controller('api/user')
 export class UserController {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly accountSecurity: AccountSecurityService,
+  ) {}
 
   @Get(':id')
   async getUser(@Param('id') id: string) {
@@ -18,5 +24,63 @@ export class UserController {
       createdAt: user.createdAt,
       updatedAt: user.updatedAt,
     };
+  }
+
+  @Post(':id/freeze-request')
+  async submitFreezeRequest(
+    @Param('id') userId: string,
+    @Body() body: { reporterId: string; reason: string; evidenceUrl?: string },
+  ) {
+    return this.accountSecurity.submitFreezeRequest(
+      userId,
+      body.reporterId,
+      body.reason,
+      body.evidenceUrl,
+    );
+  }
+
+  @Get(':id/freeze-requests')
+  async getFreezeRequests(@Param('id') userId: string) {
+    return this.accountSecurity.getFreezeRequests(userId);
+  }
+
+  @Put('freeze-request/:requestId/review')
+  // @UseGuards(AdminGuard) // TODO: Add admin guard
+  async reviewFreezeRequest(
+    @Param('requestId') requestId: string,
+    @Body() body: { adminId: string; approved: boolean; adminNotes?: string },
+  ) {
+    return this.accountSecurity.reviewFreezeRequest(
+      requestId,
+      body.adminId,
+      body.approved,
+      body.adminNotes,
+    );
+  }
+
+  @Put(':id/unfreeze')
+  // @UseGuards(AdminGuard) // TODO: Add admin guard
+  async unfreezeAccount(
+    @Param('id') userId: string,
+    @Body() body: { adminId: string; reason: string },
+  ) {
+    return this.accountSecurity.unfreezeAccount(userId, body.adminId, body.reason);
+  }
+
+  @Get(':id/frozen-status')
+  async getFrozenStatus(@Param('id') userId: string) {
+    const isFrozen = await this.accountSecurity.isAccountFrozen(userId);
+    return { isFrozen };
+  }
+
+  @Get('freeze-requests/pending')
+  // @UseGuards(AdminGuard) // TODO: Add admin guard
+  async getPendingFreezeRequests() {
+    return this.accountSecurity.getPendingFreezeRequests();
+  }
+
+  @Post(':id/can-transact')
+  async canProceedWithTransaction(@Param('id') userId: string) {
+    return this.accountSecurity.canProceedWithTransaction(userId);
   }
 }

--- a/backend/src/user/account-security.service.ts
+++ b/backend/src/user/account-security.service.ts
@@ -1,0 +1,193 @@
+import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class AccountSecurityService {
+  private readonly logger = new Logger(AccountSecurityService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Submit a freeze request for an account
+   */
+  async submitFreezeRequest(
+    userId: string,
+    reporterId: string,
+    reason: string,
+    evidenceUrl?: string,
+  ) {
+    // Check if user exists
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Check if there's already a pending request
+    const existingRequest = await this.prisma.accountFreezeRequest.findFirst({
+      where: {
+        userId,
+        status: 'PENDING',
+      },
+    });
+
+    if (existingRequest) {
+      throw new BadRequestException('A freeze request is already pending for this account');
+    }
+
+    // Create the freeze request
+    const request = await this.prisma.accountFreezeRequest.create({
+      data: {
+        userId,
+        reporterId,
+        reason,
+        evidenceUrl,
+      },
+    });
+
+    this.logger.log(`Freeze request submitted for user ${userId} by ${reporterId}`);
+
+    return request;
+  }
+
+  /**
+   * Admin review of freeze request
+   */
+  async reviewFreezeRequest(
+    requestId: string,
+    adminId: string,
+    approved: boolean,
+    adminNotes?: string,
+  ) {
+    const request = await this.prisma.accountFreezeRequest.findUnique({
+      where: { id: requestId },
+      include: { user: true },
+    });
+
+    if (!request) {
+      throw new NotFoundException('Freeze request not found');
+    }
+
+    if (request.status !== 'PENDING') {
+      throw new BadRequestException('Request has already been reviewed');
+    }
+
+    const newStatus = approved ? 'APPROVED' : 'REJECTED';
+
+    // Update the request
+    const updatedRequest = await this.prisma.accountFreezeRequest.update({
+      where: { id: requestId },
+      data: {
+        status: newStatus,
+        adminNotes,
+        reviewedBy: adminId,
+        reviewedAt: new Date(),
+      },
+    });
+
+    // If approved, freeze the account
+    if (approved) {
+      await this.prisma.user.update({
+        where: { id: request.userId },
+        data: { isFrozen: true },
+      });
+
+      this.logger.log(`Account ${request.userId} frozen by admin ${adminId}`);
+    }
+
+    return updatedRequest;
+  }
+
+  /**
+   * Unfreeze an account (admin only)
+   */
+  async unfreezeAccount(userId: string, adminId: string, reason: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (!user.isFrozen) {
+      throw new BadRequestException('Account is not frozen');
+    }
+
+    // Update user
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { isFrozen: false },
+    });
+
+    // Log the unfreeze action (could create an audit log table)
+    this.logger.log(`Account ${userId} unfrozen by admin ${adminId}. Reason: ${reason}`);
+
+    return { success: true, message: 'Account unfrozen successfully' };
+  }
+
+  /**
+   * Check if an account is frozen
+   */
+  async isAccountFrozen(userId: string): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { isFrozen: true },
+    });
+
+    return user?.isFrozen ?? false;
+  }
+
+  /**
+   * Get freeze requests for a user
+   */
+  async getFreezeRequests(userId: string) {
+    return this.prisma.accountFreezeRequest.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * Get all pending freeze requests (admin)
+   */
+  async getPendingFreezeRequests() {
+    return this.prisma.accountFreezeRequest.findMany({
+      where: { status: 'PENDING' },
+      include: {
+        user: {
+          select: {
+            id: true,
+            walletAddress: true,
+            reputationScore: true,
+          },
+        },
+        reporter: {
+          select: {
+            id: true,
+            walletAddress: true,
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
+   * Validate if a transaction can proceed (used by relay service)
+   */
+  async canProceedWithTransaction(userId: string): Promise<{ allowed: boolean; reason?: string }> {
+    const isFrozen = await this.isAccountFrozen(userId);
+
+    if (isFrozen) {
+      return {
+        allowed: false,
+        reason: 'Account is frozen due to security concerns',
+      };
+    }
+
+    return { allowed: true };
+  }
+}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UserController } from '../user.controller';
+import { AccountSecurityService } from './account-security.service';
+import { DatabaseModule } from '../database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [UserController],
+  providers: [AccountSecurityService],
+  exports: [AccountSecurityService],
+})
+export class UserModule {}


### PR DESCRIPTION
Implemented 'Emergency Freeze' for Individual Accounts

Context
Reacting to reported identity theft.

Problem
If a user's wallet is stolen, they can't stop the thief from withdrawing their NovaFund assets.

Suggested Execution
Build a 'Freeze' mechanism.
User files a report with off-chain identity proof -> Admin freezes account off-chain.
Future withdrawal meta-txs are rejected by the backend relay.
Acceptance Criteria
Protection for users during account compromise.
Strict procedures for 'unfreezing'.
References
backend/src/user/account-security.service.ts

closes #431 