### PR TITLE
Feat: Implement dynamic milestone deadline extensions (#284)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -231,6 +231,7 @@ impl EscrowContract {
             project_id,
             description_hash: description_hash.clone(),
             amount,
+            deadline: env.ledger().timestamp() + 30 * 86400, // 30 days default
             status: MilestoneStatus::Pending,
             proof_hash: empty_hash,
             approval_count: 0,
@@ -802,6 +803,78 @@ impl EscrowContract {
     /// Inspect the current emergency rescue state for a project.
     pub fn get_emergency_withdraw_state(env: Env, project_id: u64) -> EmergencyWithdrawState {
         storage::get_emergency_withdraw_state(&env, project_id)
+    }
+
+    /// Request an extension for a milestone deadline
+    pub fn request_extension(
+        env: Env,
+        project_id: u64,
+        milestone_id: u64,
+        new_deadline: u64,
+    ) -> Result<(), Error> {
+        let escrow = get_escrow(&env, project_id)?;
+        escrow.creator.require_auth();
+
+        let milestone = get_milestone(&env, project_id, milestone_id)?;
+
+        // Ensure new deadline is in the future
+        if new_deadline <= env.ledger().timestamp() {
+            return Err(Error::InvInput);
+        }
+
+        // Initialize extension request
+        let req = ExtensionRequest {
+            new_deadline,
+            approvals: Vec::new(&env),
+        };
+        storage::set_extension_request(&env, project_id, milestone_id, &req);
+
+        env.events().publish(
+            (MILESTONE_EXT_REQ,),
+            (project_id, milestone_id, new_deadline),
+        );
+
+        Ok(())
+    }
+
+    /// Approve an extension request for a milestone deadline
+    pub fn approve_extension(
+        env: Env,
+        project_id: u64,
+        milestone_id: u64,
+        validator: Address,
+    ) -> Result<(), Error> {
+        validator.require_auth();
+
+        let escrow = get_escrow(&env, project_id)?;
+        validation::validate_validator(&escrow, &validator)?;
+
+        let mut req = storage::get_extension_request(&env, project_id, milestone_id)?;
+        let mut milestone = get_milestone(&env, project_id, milestone_id)?;
+
+        if req.approvals.contains(&validator) {
+            return Err(Error::AlreadyVoted);
+        }
+
+        req.approvals.push_back(validator.clone());
+        let total_validators = escrow.validators.len() as u32;
+        // >= 51% of project investors (validators)
+        let required_approvals = (total_validators * 51 + 99) / 100;
+
+        if req.approvals.len() as u32 >= required_approvals {
+            milestone.deadline = req.new_deadline;
+            set_milestone(&env, project_id, milestone_id, &milestone);
+            storage::clear_extension_request(&env, project_id, milestone_id);
+
+            env.events().publish(
+                (MILESTONE_EXT_APPR,),
+                (project_id, milestone_id, req.new_deadline),
+            );
+        } else {
+            storage::set_extension_request(&env, project_id, milestone_id, &req);
+        }
+
+        Ok(())
     }
 
     /// Initiate a dispute on a milestone

--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -2,7 +2,7 @@ use shared::errors::Error;
 use shared::types::{
     Amount, Dispute, EscrowInfo, JurorInfo, Milestone, PauseState, PendingUpgrade, VoteCommitment,
 };
-use soroban_sdk::{Address, Env, Vec};
+use soroban_sdk::{contracttype, Address, Env, Vec};
 
 use crate::{EmergencyWithdrawState, EmergencyWithdrawStatus};
 
@@ -361,3 +361,28 @@ pub fn set_emergency_withdraw_state(env: &Env, project_id: u64, state: &Emergenc
     let key = (EMERGENCY_WITHDRAW_PREFIX, project_id);
     env.storage().persistent().set(&key, state);
 }
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ExtensionRequest {
+    pub new_deadline: u64,
+    pub approvals: Vec<Address>,
+}
+
+const EXTENSION_REQUEST_PREFIX: &str = "ext_req";
+
+pub fn get_extension_request(env: &Env, project_id: u64, milestone_id: u64) -> Result<ExtensionRequest, Error> {
+    let key = (EXTENSION_REQUEST_PREFIX, project_id, milestone_id);
+    env.storage().persistent().get::<(&str, u64, u64), ExtensionRequest>(&key).ok_or(Error::NotFound)
+}
+
+pub fn set_extension_request(env: &Env, project_id: u64, milestone_id: u64, req: &ExtensionRequest) {
+    let key = (EXTENSION_REQUEST_PREFIX, project_id, milestone_id);
+    env.storage().persistent().set(&key, req);
+}
+
+pub fn clear_extension_request(env: &Env, project_id: u64, milestone_id: u64) {
+    let key = (EXTENSION_REQUEST_PREFIX, project_id, milestone_id);
+    env.storage().persistent().remove(&key);
+}
+

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -21,6 +21,8 @@ pub const MILESTONE_SUBMITTED: Symbol = symbol_short!("m_submit");
 pub const MILESTONE_APPROVED: Symbol = symbol_short!("m_apprv");
 pub const MILESTONE_REJECTED: Symbol = symbol_short!("m_reject");
 pub const MILESTONE_COMPLETED: Symbol = symbol_short!("milestone");
+pub const MILESTONE_EXT_REQ: Symbol = symbol_short!("m_ext_req");
+pub const MILESTONE_EXT_APPR: Symbol = symbol_short!("m_ext_app");
 pub const VALIDATORS_UPDATED: Symbol = symbol_short!("v_update");
 
 // Dispute events

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -83,6 +83,7 @@ pub struct Milestone {
     pub project_id: u64,
     pub description_hash: Hash,
     pub amount: Amount,
+    pub deadline: Timestamp,
     pub status: MilestoneStatus,
     pub proof_hash: Hash,
     pub approval_count: u32,


### PR DESCRIPTION
Resolves #284

**Context**
Development timelines often shift, but milestone deadlines are strictly hardcoded at launch. This rigidity creates friction between creators and investors.

**Changes proposed in this pull request:**
- Added a `deadline` field to the `Milestone` struct in `contracts/shared/src/types.rs`.
- Updated `create_milestone` in `contracts/escrow/src/lib.rs` to initialize a default 30-day deadline.
- Implemented `request_extension(new_deadline)` to allow project creators to propose a new deadline, tracking the request in `contracts/escrow/src/storage.rs`.
- Implemented `approve_extension(validator)` which calculates the consensus of the investors (validators) and updates the deadline only if `>= 51%` threshold is met.
- Introduced a clear event trail by publishing `MILESTONE_EXT_REQ` and `MILESTONE_EXT_APPR` events inside `contracts/shared/src/events.rs`.

**Acceptance Criteria Met:**
- [x] Deadline updated only via investor consensus (>= 51%).
- [x] Clear event trail of extensions using Soroban events.

Closes #284 