### PR TITLE
Feat: Implement smooth page transitions (#301)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Footer from "../components/layout/Footer";
 import { NotificationProvider } from "../contexts/NotificationContext";
 import { SocialProvider } from "../contexts/SocialContext";
 import { LiveNotificationToast } from "../components/notifications/LiveNotificationToast";
+import { PageTransition } from "../components/layout/PageTransition";
 import "../styles/globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -26,9 +27,9 @@ export default function RootLayout({
           <SocialProvider>
             <Header />
             <LiveNotificationToast />
-            <main className="flex-1 max-w-7xl mx-auto px-4 py-6 pt-16">
+            <PageTransition className="flex-1 max-w-7xl mx-auto px-4 py-6 pt-16">
               {children}
-            </main>
+            </PageTransition>
             <Footer />
           </SocialProvider>
         </NotificationProvider>

--- a/frontend/src/components/layout/PageTransition.tsx
+++ b/frontend/src/components/layout/PageTransition.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { usePathname } from "next/navigation";
+import { ReactNode } from "react";
+
+export function PageTransition({ children, className }: { children: ReactNode; className?: string }) {
+  const pathname = usePathname();
+
+  return (
+    <motion.main
+      key={pathname}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+      className={className}
+    >
+      {children}
+    </motion.main>
+  );
+}


### PR DESCRIPTION
Resolves #301

**Context**
Page switching is currently abrupt, which reduces the "App-like" feel of our decentralized platform. Smooth transitions between pages enhance the overall user experience.

**Changes proposed in this pull request:**
- Created a new `<PageTransition>` Client Component (`frontend/src/components/layout/PageTransition.tsx`) using `framer-motion`.
- Used `usePathname()` to automatically trigger the animation on route changes without forcing the entire layout into a Client Component.
- Replaced the static `<main>` tag in `frontend/src/app/layout.tsx` with the new `<PageTransition>` wrapper.
- Implemented `initial={{ opacity: 0, y: 10 }}` and `animate={{ opacity: 1, y: 0 }}` transitions for smooth fade/slide effects.

**Acceptance Criteria Met:**
- [x] Pages slide or fade in smoothly.
- [x] No performance lag on low-end devices (handled efficiently by `framer-motion`'s optimized rendering).



Closes #301 