### PR TITLE
perf: optimize leaderboard query with redis caching and cron refresh

### DIFF
--- a/backend/src/project/investment-intent.service.ts
+++ b/backend/src/project/investment-intent.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, BadRequestException, NotFoundException } from '@nes
 import { PrismaService } from '../prisma.service';
 import { PathfinderService, PaymentPath, RouteAnalysis } from '../stellar/pathfinder.service';
 import { RedisService } from '../redis/redis.service';
+import { LeaderboardService } from '../reputation/leaderboard.service';
 import {
   InvestmentIntentDto,
   CreateInvestmentIntentInputDto,
@@ -20,6 +21,7 @@ export class InvestmentIntentService {
     private readonly prisma: PrismaService,
     private readonly pathfinder: PathfinderService,
     private readonly redis: RedisService,
+    private readonly leaderboardService: LeaderboardService,
   ) {}
 
   /**
@@ -209,6 +211,9 @@ export class InvestmentIntentService {
 
     // Invalidate cache
     await this.invalidateIntentCache(id);
+
+    // Trigger leaderboard refresh check
+    await this.leaderboardService.handleMassiveInvestment(Number(updated.investmentAmount));
 
     this.logger.log(`Approved investment intent ${id}`);
 

--- a/backend/src/project/project.module.ts
+++ b/backend/src/project/project.module.ts
@@ -6,9 +6,10 @@ import { InvestmentIntentService } from './investment-intent.service';
 import { InvestmentIntentResolver } from './investment-intent.resolver';
 import { TaggerService } from './tagger.service';
 import { StellarModule } from '../stellar/stellar.module';
+import { ReputationModule } from '../reputation/reputation.module';
 
 @Module({
-  imports: [StellarModule],
+  imports: [StellarModule, ReputationModule],
   providers: [
     ProjectResolver,
     ProjectService,

--- a/backend/src/reputation/leaderboard.service.ts
+++ b/backend/src/reputation/leaderboard.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma.service';
+import { RedisService } from '../redis/redis.service';
+
+export interface LeaderboardEntry {
+  userId: string;
+  walletAddress: string;
+  totalInvested: number;
+  rank: number;
+}
+
+@Injectable()
+export class LeaderboardService {
+  private readonly logger = new Logger(LeaderboardService.name);
+  private readonly CACHE_KEY = 'leaderboard:top_investors';
+  private readonly CACHE_TTL = 3600; // 1 hour
+  private readonly MASSIVE_INVESTMENT_THRESHOLD = 10000;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly redis: RedisService,
+  ) {}
+
+  /**
+   * Get the current leaderboard from cache
+   */
+  async getTopInvestors(limit: number = 100): Promise<LeaderboardEntry[]> {
+    const cached = await this.redis.get<LeaderboardEntry[]>(this.CACHE_KEY);
+    if (cached) {
+      this.logger.debug('Leaderboard cache hit');
+      return cached.slice(0, limit);
+    }
+
+    this.logger.log('Leaderboard cache miss, refreshing...');
+    const leaderboard = await this.refreshTopInvestorsCache();
+    return leaderboard.slice(0, limit);
+  }
+
+  /**
+   * Refresh the leaderboard cache by querying the database
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async refreshTopInvestorsCache(): Promise<LeaderboardEntry[]> {
+    this.logger.log('Refreshing top investors leaderboard cache...');
+
+    try {
+      const topInvestors = await this.prisma.investmentIntent.groupBy({
+        by: ['investorId'],
+        where: {
+          status: 'APPROVED', // Assuming APPROVED/EXECUTED means a successful investment
+        },
+        _sum: {
+          investmentAmount: true,
+        },
+        orderBy: {
+          _sum: {
+            investmentAmount: 'desc',
+          },
+        },
+        take: 1000, // Cache top 1000 investors for scalability
+      });
+
+      // Fetch user details for the top investors
+      const userIds = topInvestors.map((ti) => ti.investorId);
+      const users = await this.prisma.user.findMany({
+        where: { id: { in: userIds } },
+        select: { id: true, walletAddress: true },
+      });
+
+      const userMap = new Map(users.map((u) => [u.id, u.walletAddress]));
+
+      const leaderboard: LeaderboardEntry[] = topInvestors.map((ti, index) => ({
+        userId: ti.investorId,
+        walletAddress: userMap.get(ti.investorId) || 'Unknown',
+        totalInvested: Number(ti._sum.investmentAmount || 0),
+        rank: index + 1,
+      }));
+
+      await this.redis.set(this.CACHE_KEY, leaderboard, this.CACHE_TTL);
+      this.logger.log(`Leaderboard cache updated with ${leaderboard.length} entries`);
+      
+      return leaderboard;
+    } catch (error) {
+      this.logger.error('Failed to refresh leaderboard cache:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Handle on-demand refresh for massive investments
+   */
+  async handleMassiveInvestment(amount: number): Promise<void> {
+    if (amount >= this.MASSIVE_INVESTMENT_THRESHOLD) {
+      this.logger.log(`Massive investment of ${amount} detected. Triggering immediate leaderboard refresh.`);
+      // Run in background to not block the current transaction
+      this.refreshTopInvestorsCache().catch(err => {
+        this.logger.error('Background leaderboard refresh failed:', err);
+      });
+    }
+  }
+}

--- a/backend/src/reputation/reputation.module.ts
+++ b/backend/src/reputation/reputation.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database.module';
 import { ReputationService } from './reputation.service';
+import { LeaderboardService } from './leaderboard.service';
+import { RedisModule } from '../redis/redis.module';
 
 @Module({
-  imports: [DatabaseModule],
-  providers: [ReputationService],
-  exports: [ReputationService],
+  imports: [DatabaseModule, RedisModule],
+  providers: [ReputationService, LeaderboardService],
+  exports: [ReputationService, LeaderboardService],
 })
 export class ReputationModule {}


### PR DESCRIPTION
This PR addresses the performance bottleneck where the leaderboard performed a full database scan on every request.

Key Changes:

Introduced LeaderboardService to manage top investor data.
Implemented Redis caching with the top_investors key.
Added a @Cron job to refresh the cache every hour for background updates.
Added an on-demand refresh trigger in InvestmentIntentService for large contributions (threshold: 10,000).
Refactored ReputationModule and ProjectModule to support cross-service communication.
Impact:

Response time for leaderboard retrieval improved from O(N) to O(1) from the database's perspective.
Enhanced user experience with live-ish updates for high-value gamification events.
Closes #438 