### PR TITLE
feat(backend): support waterfall payouts, ops gas reporting, ecosystem feed, and GraphQL cost guards

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,6 +55,7 @@
     "compromise": "^14.15.0",
     "decimal.js": "^10.6.0",
     "graphql": "^16.13.2",
+    "graphql-query-complexity": "^1.1.0",
     "ioredis": "^5.10.1",
     "ipfs-http-client": "^60.0.1",
     "node-cron": "^4.2.1",

--- a/backend/prisma/migrations/20260425000000_add_waterfall_operational_costs_ecosystem/migration.sql
+++ b/backend/prisma/migrations/20260425000000_add_waterfall_operational_costs_ecosystem/migration.sql
@@ -1,0 +1,76 @@
+-- CreateEnum
+CREATE TYPE "PayoutRecipientType" AS ENUM ('INVESTORS', 'CREATOR', 'PLATFORM', 'RESERVE');
+
+-- CreateTable
+CREATE TABLE "project_payout_tiers" (
+    "id" TEXT NOT NULL,
+    "project_id" TEXT NOT NULL,
+    "tier_order" INTEGER NOT NULL,
+    "recipient_type" "PayoutRecipientType" NOT NULL,
+    "max_amount" BIGINT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_payout_tiers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "operational_costs" (
+    "id" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "total_fee_charged" BIGINT NOT NULL DEFAULT 0,
+    "event_count" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "operational_costs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "operational_cost_events" (
+    "id" TEXT NOT NULL,
+    "tx_hash" TEXT,
+    "source" TEXT NOT NULL,
+    "fee_charged" BIGINT NOT NULL,
+    "ledger" INTEGER,
+    "captured_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "operational_cost_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "stellar_ecosystem_snapshots" (
+    "id" TEXT NOT NULL,
+    "snapshot_date" TIMESTAMP(3) NOT NULL,
+    "top_traded_assets" JSONB NOT NULL,
+    "dex_volume_24h" BIGINT NOT NULL DEFAULT 0,
+    "rwa_dex_volume_24h" BIGINT NOT NULL DEFAULT 0,
+    "source" TEXT NOT NULL DEFAULT 'horizon',
+    "captured_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "stellar_ecosystem_snapshots_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "project_payout_tiers_project_id_tier_order_key" ON "project_payout_tiers"("project_id", "tier_order");
+CREATE INDEX "project_payout_tiers_project_id_idx" ON "project_payout_tiers"("project_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "operational_costs_date_key" ON "operational_costs"("date");
+CREATE INDEX "operational_costs_date_idx" ON "operational_costs"("date");
+
+-- CreateIndex
+CREATE INDEX "operational_cost_events_captured_at_idx" ON "operational_cost_events"("captured_at");
+CREATE INDEX "operational_cost_events_source_idx" ON "operational_cost_events"("source");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stellar_ecosystem_snapshots_snapshot_date_key" ON "stellar_ecosystem_snapshots"("snapshot_date");
+CREATE INDEX "stellar_ecosystem_snapshots_captured_at_idx" ON "stellar_ecosystem_snapshots"("captured_at");
+
+-- AddForeignKey
+ALTER TABLE "project_payout_tiers"
+ADD CONSTRAINT "project_payout_tiers_project_id_fkey"
+FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -69,6 +69,7 @@ model Project {
   contributions Contribution[]
   milestones    Milestone[]
   shortlinks    Shortlink[]
+  payoutTiers   ProjectPayoutTier[]
 
   @@map("projects")
 }
@@ -426,6 +427,69 @@ model YieldEvent {
   @@index([escrowId])
   @@index([isActive])
   @@map("yield_events")
+}
+
+model ProjectPayoutTier {
+  id            String             @id @default(cuid())
+  projectId     String             @map("project_id")
+  project       Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  tierOrder     Int                @map("tier_order")
+  recipientType PayoutRecipientType @map("recipient_type")
+  maxAmount     BigInt?            @map("max_amount")
+  createdAt     DateTime           @default(now()) @map("created_at")
+  updatedAt     DateTime           @updatedAt @map("updated_at")
+
+  @@unique([projectId, tierOrder])
+  @@index([projectId])
+  @@map("project_payout_tiers")
+}
+
+enum PayoutRecipientType {
+  INVESTORS
+  CREATOR
+  PLATFORM
+  RESERVE
+}
+
+model OperationalCost {
+  id               String   @id @default(cuid())
+  date             DateTime @unique
+  totalFeeCharged  BigInt   @default(0) @map("total_fee_charged")
+  eventCount       Int      @default(0) @map("event_count")
+  createdAt        DateTime @default(now()) @map("created_at")
+  updatedAt        DateTime @updatedAt @map("updated_at")
+
+  @@index([date])
+  @@map("operational_costs")
+}
+
+model OperationalCostEvent {
+  id               String   @id @default(cuid())
+  txHash           String?  @map("tx_hash")
+  source           String
+  feeCharged       BigInt   @map("fee_charged")
+  ledger           Int?     
+  capturedAt       DateTime @default(now()) @map("captured_at")
+  createdAt        DateTime @default(now()) @map("created_at")
+
+  @@index([capturedAt])
+  @@index([source])
+  @@map("operational_cost_events")
+}
+
+model StellarEcosystemSnapshot {
+  id                String   @id @default(cuid())
+  snapshotDate      DateTime @unique @map("snapshot_date")
+  topTradedAssets   Json     @map("top_traded_assets")
+  dexVolume24h      BigInt   @default(0) @map("dex_volume_24h")
+  rwaDexVolume24h   BigInt   @default(0) @map("rwa_dex_volume_24h")
+  source            String   @default("horizon")
+  capturedAt        DateTime @default(now()) @map("captured_at")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  @@index([capturedAt])
+  @@map("stellar_ecosystem_snapshots")
 }
 
 model TokenPrice {

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,12 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
+import { ConfigService } from '@nestjs/config';
+import {
+  createComplexityRule,
+  simpleEstimator,
+  fieldExtensionsEstimator,
+} from 'graphql-query-complexity';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { validateEnv } from './config/env.validation';
@@ -21,6 +27,7 @@ import { GraphQLRateLimitModule } from './graphql/graphql-rate-limit.module';
 import { UserModule } from './user/user.module';
 import { ShortlinkModule } from './shortlink/shortlink.module';
 import { AdminModule } from './admin/admin.module';
+import { SupportModule } from './support/support.module';
 
 @Module({
   imports: [
@@ -31,10 +38,25 @@ import { AdminModule } from './admin/admin.module';
     }),
     RedisModule,
     StellarModule,
-    GraphQLModule.forRoot<ApolloDriverConfig>({
-      driver: ApolloDriver,
-      autoSchemaFile: true,
-      playground: true,
+    GraphQLModule.forRootAsync<ApolloDriverConfig>({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => {
+        const maxQueryCost = config.get<number>('GRAPHQL_MAX_QUERY_COST', 1000);
+
+        return {
+          driver: ApolloDriver,
+          autoSchemaFile: true,
+          playground: true,
+          validationRules: [
+            createComplexityRule({
+              maximumComplexity: maxQueryCost,
+              variables: {},
+              estimators: [fieldExtensionsEstimator(), simpleEstimator({ defaultComplexity: 1 })],
+            }),
+          ],
+        };
+      },
     }),
     GraphQLRateLimitModule,
     ReputationModule,

--- a/backend/src/bridge/bridge.module.ts
+++ b/backend/src/bridge/bridge.module.ts
@@ -3,9 +3,10 @@ import { BridgeController } from './bridge.controller';
 import { BridgeService } from './bridge.service';
 import { BridgePollTask } from './tasks/bridge-poll.task';
 import { DatabaseModule } from '../database.module';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, StellarModule],
   controllers: [BridgeController],
   providers: [BridgeService, BridgePollTask],
   exports: [BridgeService],

--- a/backend/src/bridge/bridge.service.ts
+++ b/backend/src/bridge/bridge.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma.service';
 import { BridgeStatus } from './enums/bridge-status.enum';
 import { RegisterBridgeTxDto, BridgeTxStatusDto } from './dto/bridge.dto';
+import { AccountingService } from '../stellar/accounting.service';
 
 /**
  * Checks a transaction hash against a chain's scanner API.
@@ -22,6 +23,7 @@ export class BridgeService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
+    private readonly accountingService: AccountingService,
   ) {
     this.adapters = this.buildAdapters();
   }
@@ -246,6 +248,13 @@ export class BridgeService {
           if (res.status === 404) return { confirmed: false, failed: false };
 
           const json = (await res.json()) as any;
+
+          await this.accountingService.recordHorizonFee('bridge.pollTransaction', {
+            fee_charged: json.fee_charged,
+            hash: json.hash,
+            ledger: json.ledger,
+          });
+
           if (json.successful === true) return { confirmed: true, failed: false };
           if (json.successful === false) return { confirmed: false, failed: true };
           return { confirmed: false, failed: false };

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -122,6 +122,10 @@ class EnvironmentVariables {
   @IsNumber()
   PRICE_FETCH_INTERVAL_MINUTES?: number;
 
+  @IsOptional()
+  @IsNumber()
+  GRAPHQL_MAX_QUERY_COST?: number;
+
   // ─── Support / Live Chat Integration ───────────────────────────────
   @IsOptional()
   @IsString()

--- a/backend/src/relay/relay.module.ts
+++ b/backend/src/relay/relay.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RelayService } from './relay.service';
 import { RelayController } from './relay.controller';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
+  imports: [StellarModule],
   providers: [RelayService],
   controllers: [RelayController],
   exports: [RelayService],

--- a/backend/src/relay/relay.service.ts
+++ b/backend/src/relay/relay.service.ts
@@ -7,6 +7,7 @@ import {
   Horizon,
   Transaction,
 } from '@stellar/stellar-sdk';
+import { AccountingService } from '../stellar/accounting.service';
 
 @Injectable()
 export class RelayService {
@@ -15,7 +16,10 @@ export class RelayService {
   private readonly server: Horizon.Server;
   private readonly networkPassphrase: string;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly accountingService: AccountingService,
+  ) {
     const stellarConfig = this.config.get('stellar');
     if (!stellarConfig.sponsorSecretKey) {
       this.logger.error('STELLAR_SPONSOR_SECRET_KEY is not configured');
@@ -64,6 +68,12 @@ export class RelayService {
       // 4. Submit to the network
       this.logger.log(`Submitting fee-bumped transaction ${innerTx.hash().toString('hex')} for source ${innerTx.source}`);
       const response = await this.server.submitTransaction(feeBumpTx);
+
+      await this.accountingService.recordHorizonFee('relay.submitTransaction', {
+        fee_charged: (response as any).fee_charged,
+        hash: response.hash,
+        ledger: response.ledger,
+      });
 
       return {
         hash: response.hash,

--- a/backend/src/stellar/accounting.service.spec.ts
+++ b/backend/src/stellar/accounting.service.spec.ts
@@ -1,0 +1,47 @@
+import { AccountingService } from './accounting.service';
+
+describe('AccountingService', () => {
+  it('records fee events and updates daily aggregate', async () => {
+    const tx = {
+      operationalCostEvent: { create: jest.fn() },
+      operationalCost: { upsert: jest.fn() },
+    };
+
+    const prisma = {
+      $transaction: jest.fn(async (cb: (inner: typeof tx) => Promise<void>) => cb(tx)),
+      operationalCost: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+
+    const service = new AccountingService(prisma as any);
+
+    await service.recordHorizonFee('relay.submitTransaction', {
+      fee_charged: '100',
+      hash: 'abc',
+      ledger: 123,
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.operationalCostEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.operationalCost.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns monthly breakdown with totals', async () => {
+    const prisma = {
+      $transaction: jest.fn(),
+      operationalCost: {
+        findMany: jest.fn().mockResolvedValue([
+          { date: new Date('2026-04-01T00:00:00.000Z'), totalFeeCharged: 100n, eventCount: 2 },
+          { date: new Date('2026-04-02T00:00:00.000Z'), totalFeeCharged: 300n, eventCount: 3 },
+        ]),
+      },
+    };
+
+    const service = new AccountingService(prisma as any);
+
+    const result = await service.getMonthlyBreakdown(2026, 4);
+
+    expect(result.totalFeeCharged).toBe('400');
+    expect(result.totalEvents).toBe(5);
+    expect(result.days).toHaveLength(2);
+  });
+});

--- a/backend/src/stellar/accounting.service.ts
+++ b/backend/src/stellar/accounting.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+interface HorizonFeePayload {
+  fee_charged?: string | number;
+  hash?: string;
+  ledger?: number;
+}
+
+@Injectable()
+export class AccountingService {
+  private readonly logger = new Logger(AccountingService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async recordHorizonFee(source: string, payload: HorizonFeePayload): Promise<void> {
+    if (payload.fee_charged === undefined || payload.fee_charged === null) {
+      return;
+    }
+
+    const feeCharged = BigInt(payload.fee_charged);
+    const dayStart = this.startOfUtcDay(new Date());
+
+    try {
+      await this.prisma.$transaction(async (tx: any) => {
+        await tx.operationalCostEvent.create({
+          data: {
+            txHash: payload.hash,
+            source,
+            feeCharged,
+            ledger: payload.ledger,
+            capturedAt: new Date(),
+          },
+        });
+
+        await tx.operationalCost.upsert({
+          where: { date: dayStart },
+          create: {
+            date: dayStart,
+            totalFeeCharged: feeCharged,
+            eventCount: 1,
+          },
+          update: {
+            totalFeeCharged: { increment: feeCharged },
+            eventCount: { increment: 1 },
+          },
+        });
+      });
+    } catch (error) {
+      this.logger.warn(`Failed to persist operational cost event: ${error.message}`);
+    }
+  }
+
+  async getMonthlyBreakdown(year: number, month: number) {
+    const firstDay = new Date(Date.UTC(year, month - 1, 1));
+    const nextMonth = new Date(Date.UTC(year, month, 1));
+
+    const rows = await (this.prisma as any).operationalCost.findMany({
+      where: {
+        date: {
+          gte: firstDay,
+          lt: nextMonth,
+        },
+      },
+      orderBy: { date: 'asc' },
+    });
+
+    const totalFeeCharged = rows.reduce((sum: bigint, row: any) => sum + BigInt(row.totalFeeCharged), 0n);
+    const totalEvents = rows.reduce((sum: number, row: any) => sum + row.eventCount, 0);
+
+    return {
+      year,
+      month,
+      totalFeeCharged: totalFeeCharged.toString(),
+      totalEvents,
+      days: rows.map((row: any) => ({
+        date: row.date.toISOString(),
+        totalFeeCharged: row.totalFeeCharged.toString(),
+        eventCount: row.eventCount,
+      })),
+    };
+  }
+
+  private startOfUtcDay(date: Date): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  }
+}

--- a/backend/src/stellar/dto/ecosystem.dto.ts
+++ b/backend/src/stellar/dto/ecosystem.dto.ts
@@ -1,0 +1,31 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class EcosystemAssetVolume {
+  @Field(() => String)
+  assetCode: string;
+
+  @Field(() => String, { nullable: true })
+  assetIssuer?: string;
+
+  @Field(() => String)
+  tradedVolume: string;
+}
+
+@ObjectType()
+export class StellarEcosystemContext {
+  @Field(() => String)
+  snapshotDate: string;
+
+  @Field(() => String)
+  capturedAt: string;
+
+  @Field(() => String)
+  dexVolume24h: string;
+
+  @Field(() => String)
+  rwaDexVolume24h: string;
+
+  @Field(() => [EcosystemAssetVolume])
+  topTradedAssets: EcosystemAssetVolume[];
+}

--- a/backend/src/stellar/dto/operational-cost.dto.ts
+++ b/backend/src/stellar/dto/operational-cost.dto.ts
@@ -1,0 +1,31 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class OperationalCostDay {
+  @Field(() => String)
+  date: string;
+
+  @Field(() => String)
+  totalFeeCharged: string;
+
+  @Field(() => Int)
+  eventCount: number;
+}
+
+@ObjectType()
+export class OperationalCostBreakdown {
+  @Field(() => Int)
+  year: number;
+
+  @Field(() => Int)
+  month: number;
+
+  @Field(() => String)
+  totalFeeCharged: string;
+
+  @Field(() => Int)
+  totalEvents: number;
+
+  @Field(() => [OperationalCostDay])
+  days: OperationalCostDay[];
+}

--- a/backend/src/stellar/ecosystem-sync.service.ts
+++ b/backend/src/stellar/ecosystem-sync.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Horizon } from '@stellar/stellar-sdk';
+import { PrismaService } from '../prisma.service';
+
+interface AssetVolumeEntry {
+  assetCode: string;
+  assetIssuer?: string;
+  tradedVolume: string;
+}
+
+@Injectable()
+export class EcosystemSyncService {
+  private readonly logger = new Logger(EcosystemSyncService.name);
+  private readonly horizonServer: Horizon.Server;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {
+    const horizonUrl = this.configService.get<string>(
+      'STELLAR_HORIZON_URL',
+      'https://horizon-testnet.stellar.org',
+    );
+    this.horizonServer = new Horizon.Server(horizonUrl);
+  }
+
+  @Cron(CronExpression.EVERY_30_MINUTES)
+  async syncEcosystemSnapshot(): Promise<void> {
+    try {
+      const snapshot = await this.buildSnapshot();
+      const snapshotDate = this.startOfUtcDay(new Date());
+
+      await (this.prisma as any).stellarEcosystemSnapshot.upsert({
+        where: { snapshotDate },
+        create: {
+          snapshotDate,
+          topTradedAssets: snapshot.topTradedAssets,
+          dexVolume24h: snapshot.dexVolume24h,
+          rwaDexVolume24h: snapshot.rwaDexVolume24h,
+          source: 'horizon',
+          capturedAt: new Date(),
+        },
+        update: {
+          topTradedAssets: snapshot.topTradedAssets,
+          dexVolume24h: snapshot.dexVolume24h,
+          rwaDexVolume24h: snapshot.rwaDexVolume24h,
+          capturedAt: new Date(),
+        },
+      });
+    } catch (error) {
+      this.logger.warn(`Failed to sync Stellar ecosystem snapshot: ${error.message}`);
+    }
+  }
+
+  async getLatestSnapshot() {
+    return (this.prisma as any).stellarEcosystemSnapshot.findFirst({
+      orderBy: { capturedAt: 'desc' },
+    });
+  }
+
+  async syncNow() {
+    await this.syncEcosystemSnapshot();
+    return this.getLatestSnapshot();
+  }
+
+  private async buildSnapshot(): Promise<{
+    topTradedAssets: AssetVolumeEntry[];
+    dexVolume24h: bigint;
+    rwaDexVolume24h: bigint;
+  }> {
+    const response = await this.horizonServer.trades().order('desc').limit(200).call();
+    const assetVolumes = new Map<string, bigint>();
+
+    for (const trade of response.records) {
+      const baseKey = this.assetKey(trade.base_asset_type, trade.base_asset_code, trade.base_asset_issuer);
+      const counterKey = this.assetKey(
+        trade.counter_asset_type,
+        trade.counter_asset_code,
+        trade.counter_asset_issuer,
+      );
+
+      const baseAmount = this.toStroops(trade.base_amount);
+      const counterAmount = this.toStroops(trade.counter_amount);
+
+      assetVolumes.set(baseKey, (assetVolumes.get(baseKey) ?? 0n) + baseAmount);
+      assetVolumes.set(counterKey, (assetVolumes.get(counterKey) ?? 0n) + counterAmount);
+    }
+
+    const sortedAssets = [...assetVolumes.entries()]
+      .sort((a, b) => (a[1] > b[1] ? -1 : 1))
+      .slice(0, 10)
+      .map(([key, volume]) => {
+        const [assetCode, assetIssuer] = key.split(':');
+        return {
+          assetCode,
+          assetIssuer: assetIssuer || undefined,
+          tradedVolume: volume.toString(),
+        };
+      });
+
+    const trackedTokens = this.configService
+      .get<string>('RWA_TRACKED_ASSETS', 'USDC,EURC,NGNC')
+      .split(',')
+      .map((item) => item.trim().toUpperCase())
+      .filter(Boolean);
+
+    const dexVolume24h = [...assetVolumes.values()].reduce((sum, value) => sum + value, 0n);
+    const rwaDexVolume24h = [...assetVolumes.entries()].reduce((sum, [key, value]) => {
+      const [assetCode] = key.split(':');
+      return trackedTokens.includes(assetCode.toUpperCase()) ? sum + value : sum;
+    }, 0n);
+
+    return {
+      topTradedAssets: sortedAssets,
+      dexVolume24h,
+      rwaDexVolume24h,
+    };
+  }
+
+  private assetKey(type: string, code?: string, issuer?: string): string {
+    if (type === 'native') {
+      return 'XLM:';
+    }
+
+    return `${code ?? 'UNKNOWN'}:${issuer ?? ''}`;
+  }
+
+  private toStroops(amount: string): bigint {
+    return BigInt(Math.floor(parseFloat(amount) * 10_000_000));
+  }
+
+  private startOfUtcDay(date: Date): Date {
+    return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  }
+}

--- a/backend/src/stellar/stellar-insights.resolver.ts
+++ b/backend/src/stellar/stellar-insights.resolver.ts
@@ -1,0 +1,53 @@
+import { Args, Int, Query, Resolver } from '@nestjs/graphql';
+import { AccountingService } from './accounting.service';
+import { EcosystemSyncService } from './ecosystem-sync.service';
+import { OperationalCostBreakdown } from './dto/operational-cost.dto';
+import { StellarEcosystemContext } from './dto/ecosystem.dto';
+
+@Resolver()
+export class StellarInsightsResolver {
+  constructor(
+    private readonly accountingService: AccountingService,
+    private readonly ecosystemSyncService: EcosystemSyncService,
+  ) {}
+
+  @Query(() => OperationalCostBreakdown, {
+    name: 'monthlyOperationalCosts',
+    description: 'Returns month-level platform gas usage and fee sponsorship totals.',
+  })
+  async getMonthlyOperationalCosts(
+    @Args('year', { type: () => Int }) year: number,
+    @Args('month', { type: () => Int }) month: number,
+  ): Promise<OperationalCostBreakdown> {
+    return this.accountingService.getMonthlyBreakdown(year, month);
+  }
+
+  @Query(() => StellarEcosystemContext, {
+    name: 'stellarEcosystemContext',
+    description: 'Returns latest top traded assets and DEX volume context from Stellar.',
+  })
+  async getStellarEcosystemContext(): Promise<StellarEcosystemContext> {
+    const latest = await this.ecosystemSyncService.getLatestSnapshot();
+
+    if (!latest) {
+      const synced = await this.ecosystemSyncService.syncNow();
+      return this.formatSnapshot(synced);
+    }
+
+    return this.formatSnapshot(latest);
+  }
+
+  private formatSnapshot(snapshot: any): StellarEcosystemContext {
+    return {
+      snapshotDate: snapshot.snapshotDate.toISOString(),
+      capturedAt: snapshot.capturedAt.toISOString(),
+      dexVolume24h: snapshot.dexVolume24h.toString(),
+      rwaDexVolume24h: snapshot.rwaDexVolume24h.toString(),
+      topTradedAssets: (snapshot.topTradedAssets ?? []).map((entry: any) => ({
+        assetCode: entry.assetCode,
+        assetIssuer: entry.assetIssuer,
+        tradedVolume: entry.tradedVolume,
+      })),
+    };
+  }
+}

--- a/backend/src/stellar/stellar.module.ts
+++ b/backend/src/stellar/stellar.module.ts
@@ -9,6 +9,9 @@ import { AssetDiscoveryService } from './asset-discovery.service';
 import { AssetDiscoveryController } from './asset-discovery.controller';
 import { PrismaService } from '../prisma.service';
 import { ScheduleModule } from '@nestjs/schedule';
+import { AccountingService } from './accounting.service';
+import { EcosystemSyncService } from './ecosystem-sync.service';
+import { StellarInsightsResolver } from './stellar-insights.resolver';
 
 @Module({
   imports: [HttpModule, ScheduleModule.forRoot()],
@@ -17,7 +20,10 @@ import { ScheduleModule } from '@nestjs/schedule';
     PathfinderService,
     FederationService,
     AssetDiscoveryService,
-    PrismaService
+    AccountingService,
+    EcosystemSyncService,
+    StellarInsightsResolver,
+    PrismaService,
   ],
   controllers: [
     RpcFallbackController,
@@ -28,7 +34,9 @@ import { ScheduleModule } from '@nestjs/schedule';
     RpcFallbackService,
     PathfinderService,
     FederationService,
-    AssetDiscoveryService
+    AssetDiscoveryService,
+    AccountingService,
+    EcosystemSyncService,
   ],
 })
 export class StellarModule {}

--- a/backend/src/yield/dto/waterfall.dto.ts
+++ b/backend/src/yield/dto/waterfall.dto.ts
@@ -1,0 +1,57 @@
+import { Field, InputType, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
+
+export enum WaterfallRecipientType {
+  INVESTORS = 'INVESTORS',
+  CREATOR = 'CREATOR',
+  PLATFORM = 'PLATFORM',
+  RESERVE = 'RESERVE',
+}
+
+registerEnumType(WaterfallRecipientType, {
+  name: 'WaterfallRecipientType',
+});
+
+@InputType()
+export class WaterfallTierInput {
+  @Field(() => Int)
+  tierOrder: number;
+
+  @Field(() => WaterfallRecipientType)
+  recipientType: WaterfallRecipientType;
+
+  @Field(() => String, { nullable: true })
+  maxAmount?: string | null;
+}
+
+@ObjectType()
+export class WaterfallTier {
+  @Field(() => Int)
+  tierOrder: number;
+
+  @Field(() => WaterfallRecipientType)
+  recipientType: WaterfallRecipientType;
+
+  @Field(() => String, { nullable: true })
+  maxAmount?: string | null;
+}
+
+@ObjectType()
+export class WaterfallAllocation {
+  @Field(() => WaterfallRecipientType)
+  recipientType: WaterfallRecipientType;
+
+  @Field(() => String)
+  amount: string;
+}
+
+@ObjectType()
+export class WaterfallSimulation {
+  @Field(() => String)
+  payoutAmount: string;
+
+  @Field(() => [WaterfallAllocation])
+  allocations: WaterfallAllocation[];
+
+  @Field(() => String)
+  unallocatedAmount: string;
+}

--- a/backend/src/yield/waterfall-engine.service.spec.ts
+++ b/backend/src/yield/waterfall-engine.service.spec.ts
@@ -1,0 +1,33 @@
+import { WaterfallEngineService, WaterfallTierRule } from './waterfall-engine.service';
+
+describe('WaterfallEngineService', () => {
+  const service = new WaterfallEngineService();
+
+  it('allocates in tier order with capped tiers', () => {
+    const tiers: WaterfallTierRule[] = [
+      { tierOrder: 1, recipientType: 'INVESTORS', maxAmount: 100_000n },
+      { tierOrder: 2, recipientType: 'CREATOR', maxAmount: 50_000n },
+      { tierOrder: 3, recipientType: 'PLATFORM', maxAmount: null },
+    ];
+
+    const result = service.calculatePayout(220_000n, tiers);
+
+    expect(result.allocations.INVESTORS).toBe(100_000n);
+    expect(result.allocations.CREATOR).toBe(50_000n);
+    expect(result.allocations.PLATFORM).toBe(70_000n);
+    expect(result.unallocatedAmount).toBe(0n);
+  });
+
+  it('leaves remainder when tiers are fully capped', () => {
+    const tiers: WaterfallTierRule[] = [
+      { tierOrder: 1, recipientType: 'INVESTORS', maxAmount: 100_000n },
+      { tierOrder: 2, recipientType: 'CREATOR', maxAmount: 50_000n },
+    ];
+
+    const result = service.calculatePayout(200_000n, tiers);
+
+    expect(result.allocations.INVESTORS).toBe(100_000n);
+    expect(result.allocations.CREATOR).toBe(50_000n);
+    expect(result.unallocatedAmount).toBe(50_000n);
+  });
+});

--- a/backend/src/yield/waterfall-engine.service.ts
+++ b/backend/src/yield/waterfall-engine.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+
+export type WaterfallRecipient = 'INVESTORS' | 'CREATOR' | 'PLATFORM' | 'RESERVE';
+
+export interface WaterfallTierRule {
+  tierOrder: number;
+  recipientType: WaterfallRecipient;
+  maxAmount: bigint | null;
+}
+
+export interface WaterfallCalculationResult {
+  allocations: Record<WaterfallRecipient, bigint>;
+  unallocatedAmount: bigint;
+}
+
+@Injectable()
+export class WaterfallEngineService {
+  calculatePayout(totalPayout: bigint, tiers: WaterfallTierRule[]): WaterfallCalculationResult {
+    if (totalPayout < 0n) {
+      throw new Error('totalPayout must be non-negative');
+    }
+
+    const sorted = [...tiers].sort((a, b) => a.tierOrder - b.tierOrder);
+    const allocations: Record<WaterfallRecipient, bigint> = {
+      INVESTORS: 0n,
+      CREATOR: 0n,
+      PLATFORM: 0n,
+      RESERVE: 0n,
+    };
+
+    let remaining = totalPayout;
+
+    for (const tier of sorted) {
+      if (remaining === 0n) {
+        break;
+      }
+
+      if (tier.maxAmount !== null && tier.maxAmount <= 0n) {
+        continue;
+      }
+
+      const tierBudget = tier.maxAmount === null ? remaining : remaining < tier.maxAmount ? remaining : tier.maxAmount;
+
+      allocations[tier.recipientType] += tierBudget;
+      remaining -= tierBudget;
+    }
+
+    return {
+      allocations,
+      unallocatedAmount: remaining,
+    };
+  }
+}

--- a/backend/src/yield/yield.module.ts
+++ b/backend/src/yield/yield.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database.module';
 import { YieldService } from './yield.service';
 import { YieldResolver } from './yield.resolver';
+import { WaterfallEngineService } from './waterfall-engine.service';
 
 @Module({
   imports: [DatabaseModule],
-  providers: [YieldService, YieldResolver],
+  providers: [YieldService, YieldResolver, WaterfallEngineService],
 })
 export class YieldModule {}

--- a/backend/src/yield/yield.resolver.ts
+++ b/backend/src/yield/yield.resolver.ts
@@ -1,6 +1,12 @@
-import { Resolver, Query } from '@nestjs/graphql';
+import { Resolver, Query, Args, Mutation } from '@nestjs/graphql';
 import { YieldService } from './yield.service';
 import { YieldStats } from './dto/yield-stats.dto';
+import {
+  WaterfallSimulation,
+  WaterfallTier,
+  WaterfallTierInput,
+  WaterfallRecipientType,
+} from './dto/waterfall.dto';
 
 @Resolver()
 export class YieldResolver {
@@ -12,5 +18,55 @@ export class YieldResolver {
   })
   async getTotalYield(): Promise<YieldStats> {
     return this.yieldService.getAggregatedYield();
+  }
+
+  @Query(() => [WaterfallTier], {
+    name: 'projectWaterfallTiers',
+    description: 'Returns configured waterfall payout tiers for a project',
+  })
+  async getProjectWaterfall(
+    @Args('projectId') projectId: string,
+  ): Promise<WaterfallTier[]> {
+    const tiers = await this.yieldService.getProjectWaterfall(projectId);
+    return tiers.map((tier) => ({
+      tierOrder: tier.tierOrder,
+      recipientType: tier.recipientType as WaterfallRecipientType,
+      maxAmount: tier.maxAmount === null ? null : tier.maxAmount.toString(),
+    }));
+  }
+
+  @Mutation(() => [WaterfallTier], {
+    name: 'configureProjectWaterfallTiers',
+    description: 'Configures per-project waterfall payout tiers',
+  })
+  async configureProjectWaterfall(
+    @Args('projectId') projectId: string,
+    @Args({ name: 'tiers', type: () => [WaterfallTierInput] }) tiers: WaterfallTierInput[],
+  ): Promise<WaterfallTier[]> {
+    const configured = await this.yieldService.configureProjectWaterfall(
+      projectId,
+      tiers.map((tier) => ({
+        tierOrder: tier.tierOrder,
+        recipientType: tier.recipientType,
+        maxAmount: tier.maxAmount ?? null,
+      })),
+    );
+
+    return configured.map((tier) => ({
+      tierOrder: tier.tierOrder,
+      recipientType: tier.recipientType as WaterfallRecipientType,
+      maxAmount: tier.maxAmount === null ? null : tier.maxAmount.toString(),
+    }));
+  }
+
+  @Query(() => WaterfallSimulation, {
+    name: 'simulateWaterfallPayout',
+    description: 'Simulates payout distribution based on configured waterfall tiers',
+  })
+  async simulateWaterfallPayout(
+    @Args('projectId') projectId: string,
+    @Args('payoutAmount') payoutAmount: string,
+  ): Promise<WaterfallSimulation> {
+    return this.yieldService.simulateProjectWaterfall(projectId, payoutAmount);
   }
 }

--- a/backend/src/yield/yield.service.ts
+++ b/backend/src/yield/yield.service.ts
@@ -1,10 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 import { YieldStats } from './dto/yield-stats.dto';
+import {
+  WaterfallEngineService,
+  WaterfallRecipient,
+  WaterfallTierRule,
+} from './waterfall-engine.service';
+
+export interface UpsertWaterfallTierInput {
+  tierOrder: number;
+  recipientType: WaterfallRecipient;
+  maxAmount: string | null;
+}
 
 @Injectable()
 export class YieldService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly waterfallEngine: WaterfallEngineService,
+  ) {}
 
   async getAggregatedYield(): Promise<YieldStats> {
     const result = await this.prisma.yieldEvent.aggregate({
@@ -22,6 +36,59 @@ export class YieldService {
     return {
       totalYield: (result._sum.amount ?? BigInt(0)).toString(),
       activeEscrowCount: activeEscrowCount.length,
+    };
+  }
+
+  async getProjectWaterfall(projectId: string): Promise<WaterfallTierRule[]> {
+    const tiers = await (this.prisma as any).projectPayoutTier.findMany({
+      where: { projectId },
+      orderBy: { tierOrder: 'asc' },
+    });
+
+    return tiers.map((tier: any) => ({
+      tierOrder: tier.tierOrder,
+      recipientType: tier.recipientType,
+      maxAmount: tier.maxAmount === null ? null : BigInt(tier.maxAmount),
+    }));
+  }
+
+  async configureProjectWaterfall(projectId: string, tiers: UpsertWaterfallTierInput[]): Promise<WaterfallTierRule[]> {
+    await this.prisma.project.findUniqueOrThrow({ where: { id: projectId } });
+
+    const normalized = [...tiers]
+      .sort((a, b) => a.tierOrder - b.tierOrder)
+      .map((tier) => ({
+        tierOrder: tier.tierOrder,
+        recipientType: tier.recipientType,
+        maxAmount: tier.maxAmount === null ? null : BigInt(tier.maxAmount),
+      }));
+
+    await this.prisma.$transaction(async (tx) => {
+      await (tx as any).projectPayoutTier.deleteMany({ where: { projectId } });
+      await (tx as any).projectPayoutTier.createMany({
+        data: normalized.map((tier) => ({
+          projectId,
+          tierOrder: tier.tierOrder,
+          recipientType: tier.recipientType,
+          maxAmount: tier.maxAmount,
+        })),
+      });
+    });
+
+    return this.getProjectWaterfall(projectId);
+  }
+
+  async simulateProjectWaterfall(projectId: string, payoutAmount: string) {
+    const tiers = await this.getProjectWaterfall(projectId);
+    const result = this.waterfallEngine.calculatePayout(BigInt(payoutAmount), tiers);
+
+    return {
+      payoutAmount,
+      allocations: Object.entries(result.allocations).map(([recipientType, amount]) => ({
+        recipientType: recipientType as WaterfallRecipient,
+        amount: amount.toString(),
+      })),
+      unallocatedAmount: result.unallocatedAmount.toString(),
     };
   }
 }


### PR DESCRIPTION
## Summary
This PR implements four backend enhancements for complex payout modeling, platform operational cost visibility, ecosystem context ingestion, and GraphQL query safety.

## What Changed
- Added configurable per-project waterfall payout tiers and simulation support.
- Added automated operational gas usage accounting by capturing Horizon `fee_charged` values and persisting daily aggregates.
- Added Stellar ecosystem sync service that stores top traded assets and DEX volume snapshots for contextual market insights.
- Added GraphQL query complexity analysis and rejection for high-cost queries via `graphql-query-complexity` with configurable max threshold.

## Implementation Details
### 1) Variable Payout / Waterfall Model (#421)
- Added `WaterfallEngineService` with tiered allocation logic.
- Added GraphQL APIs to configure and query per-project payout tiers:
  - `configureProjectWaterfallTiers`
  - `projectWaterfallTiers`
  - `simulateWaterfallPayout`
- Added Prisma model `ProjectPayoutTier` and enum `PayoutRecipientType`.

### 2) Automated Gas Usage Reporting (#394)
- Added `AccountingService` for recording Horizon `fee_charged` events.
- Added persistence models:
  - `OperationalCostEvent` (event-level fee entries)
  - `OperationalCost` (daily totals)
- Wired fee recording into Horizon-backed flows in relay and bridge paths.
- Added GraphQL query `monthlyOperationalCosts(year, month)` for auditing/reporting.

### 3) Stellar Ecosystem Data Feed (#414)
- Added `EcosystemSyncService` with scheduled snapshot updates.
- Captures:
  - Top traded assets
  - Total DEX volume (24h)
  - RWA-focused DEX volume (24h, configurable tracked assets)
- Added GraphQL query `stellarEcosystemContext` to expose latest ecosystem context.
- Added persistence model `StellarEcosystemSnapshot`.

### 4) GraphQL Query Cost Analysis (#404)
- Added `graphql-query-complexity` validation rule in GraphQL module bootstrap.
- Enforces configurable max query cost (`GRAPHQL_MAX_QUERY_COST`, default `1000`).
- Keeps API resource usage bounded and safer from expensive depth/complexity abuse.

## Database Migration
- Added migration:
  - `backend/prisma/migrations/20260425000000_add_waterfall_operational_costs_ecosystem/migration.sql`
- Updated `backend/prisma/schema.prisma` accordingly.

## Tests
- Added unit tests:
  - `waterfall-engine.service.spec.ts`
  - `accounting.service.spec.ts`
- Ran targeted tests successfully:
  - `pnpm jest --runInBand src/yield/waterfall-engine.service.spec.ts src/stellar/accounting.service.spec.ts`

## Notes
- Full backend build currently reports multiple existing unrelated repository errors; this PR validated changed files and focused tests for introduced functionality.

Closes #421
Closes #394
Closes #414
Closes #404